### PR TITLE
pytblis support

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Prism is being developed as a platform for calculating excited-state energies an
 - Optional: matplotlib >= 3.9 for plotting spectra;
 - Optional: sympy >= 1.12 for spin–orbit coupling;
 - Optional: [socutils](https://github.com/xubwa/socutils) for spin–orbit coupling;
-- Optional: [opt_einsum](https://optimized-einsum.readthedocs.io/en/stable/) for faster tensor contractions.
+- Optional: [opt_einsum](https://optimized-einsum.readthedocs.io/en/stable/) or [pytblis](https://pytblis.readthedocs.io/) for faster tensor contractions.
 
 ## Installation
 1) Install [PySCF](https://github.com/pyscf/pyscf/) and make sure it is included in the ``$PYTHONPATH`` environment variable
@@ -47,20 +47,21 @@ mf = scf.RHF(mol).run()
 mc = mcscf.CASSCF(mf, 6, 6).run()
 ```
 
-Once the reference calculation is successfully completed, the objects of Hartree-Fock and CASSCF classes (```mf``` and ```mc```) are passed to Prism. 
-For example, the NEVPT2 energy calculation for the reference CASSCF state can be performed as follows:
+Once the reference calculation is successfully completed, the objects of Hartree-Fock and CASSCF classes (```mf``` and ```mc```) are passed to Prism via the interface. The `backend` parameter controls which tensor contraction library is used, and can be set to `numpy`, `opt_einsum`, or `pytblis`. If not specified (or set to `None`), `numpy` is used by default.
+
+For example, a NEVPT2 energy calculation for the reference CASSCF state can be performed as follows:
 
 ```python
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'pytblis')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.method = "nevpt2"
 e_tot, e_corr, osc = nevpt.kernel()
 ```
 
-Alternatively, the CVS-IP-MR-ADC calculation of core ionized states can be performed as:
+Alternatively, a CVS-IP-MR-ADC calculation of core ionized states can be performed as:
 
 ```python
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method = "mr-adc(2)"
 mr_adc.method_type = "cvs-ip"

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ mf = scf.RHF(mol).run()
 mc = mcscf.CASSCF(mf, 6, 6).run()
 ```
 
-Once the reference calculation is successfully completed, the objects of Hartree-Fock and CASSCF classes (```mf``` and ```mc```) are passed to Prism via the interface. The `backend` parameter controls which tensor contraction library is used, and can be set to `numpy`, `opt_einsum`, or `pytblis`. If not specified (or set to `None`), `numpy` is used by default.
+Once the reference calculation is successfully completed, the Hartree-Fock and CASSCF objects (```mf``` and ```mc```) are passed to Prism via the interface. The `backend` parameter controls which tensor contraction library is used, and can be set to `numpy`, `opt_einsum`, or `pytblis`. If not specified (or set to `None`), Prism automatically select the best backend available.
 
 For example, a NEVPT2 energy calculation for the reference CASSCF state can be performed as follows:
 

--- a/examples/mr_adc/01-cvs_ip_mr_adc_2.py
+++ b/examples/mr_adc/01-cvs_ip_mr_adc_2.py
@@ -28,7 +28,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6)
 emc = mc.mc1step()[0]
 
 # CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.ncvs = 2

--- a/examples/mr_adc/02-multiple_cvs_spaces.py
+++ b/examples/mr_adc/02-multiple_cvs_spaces.py
@@ -30,7 +30,7 @@ emc = mc.mc1step()[0]
 # CVS-IP-MR-ADC calculations
 ## First calculation: CVS space for O 1s^{-1} states
 print("## First calculation: CVS space for O 1s^{-1} states")
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.ncvs = 1
@@ -41,7 +41,7 @@ e, p, x = mr_adc.kernel()
 
 ## Second calculation: CVS space for C 1s^{-1} states
 print("## Second calculation: CVS space for C 1s^{-1} states")
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.ncvs = 2

--- a/examples/mr_adc/03-cvs_ip_mr_adc_2_x.py
+++ b/examples/mr_adc/03-cvs_ip_mr_adc_2_x.py
@@ -28,7 +28,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6)
 emc = mc.mc1step()[0]
 
 # CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.method = "mr-adc(2)-x"

--- a/examples/mr_adc/04-dyson_mos.py
+++ b/examples/mr_adc/04-dyson_mos.py
@@ -33,7 +33,7 @@ mo = pyscf.mcscf.sort_mo(mc, mf.mo_coeff, cas_list)
 emc = mc.mc1step(mo)[0]
 
 # CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.ncvs = 3

--- a/examples/mr_adc/05-density_fitting.py
+++ b/examples/mr_adc/05-density_fitting.py
@@ -28,7 +28,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6)
 emc = mc.mc1step()[0]
 
 ## CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.method = "mr-adc(2)"
@@ -49,7 +49,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6).density_fit('aug-cc-pvdz-jkfit')
 emc = mc.mc1step()[0]
 
 ## CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.method = "mr-adc(2)"

--- a/examples/mr_adc/06-einsum-options.py
+++ b/examples/mr_adc/06-einsum-options.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python
+
+'''
+CVS-IP-MR-ADC(2) calculations for C2
+'''
+
+import pyscf.gto
+import pyscf.scf
+import pyscf.mcscf
+import prism.interface
+import prism.mr_adc
+
+mol = pyscf.gto.Mole()
+mol.atom = 'C 0 0 0; C 0 0 1.2'
+mol.basis = 'ccpvdz'
+mol.build()
+mol.verbose = 4
+
+# RHF calculation as guess for CASSCF
+mf = pyscf.scf.RHF(mol)
+mf.kernel()
+
+# CASSCF calculation
+mc = pyscf.mcscf.CASSCF(mf, 6, (4, 2))
+emc = mc.mc1step()[0]
+
+# CVS-IP-MR-ADC calculation with opt_einsum
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
+mr_adc = prism.mr_adc.MRADC(interface)
+mr_adc.method_type = "cvs-ip"
+mr_adc.ncvs = 2
+mr_adc.nroots = 3
+mr_adc.kernel()
+
+# CVS-IP-MR-ADC calculation with pytblis
+interface = prism.interface.PYSCF(mf, mc, backend = 'pytblis')
+mr_adc = prism.mr_adc.CVSIPMRADC(interface)
+mr_adc.ncvs = 2
+mr_adc.nroots = 3
+mr_adc.kernel()
+
+# CVS-IP-MR-ADC calculation with numpy
+interface = prism.interface.PYSCF(mf, mc, backend = 'numpy')
+mr_adc = prism.mr_adc.CVSIPMRADC(interface)
+mr_adc.ncvs = 2
+mr_adc.nroots = 3
+mr_adc.kernel()
+

--- a/examples/nevpt/01-nevpt2-basic.py
+++ b/examples/nevpt/01-nevpt2-basic.py
@@ -44,12 +44,12 @@ mc.analyze()
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
 # NEVPT2 with frozen core
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.nfrozen = 1
 e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/nevpt/02-nevpt2-references.py
+++ b/examples/nevpt/02-nevpt2-references.py
@@ -31,7 +31,7 @@ mf.kernel()
 mc = pyscf.mcscf.CASSCF(mf, 6, 6)
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
@@ -43,7 +43,7 @@ weights = np.ones(n_states)/n_states
 mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
@@ -55,6 +55,6 @@ mc = pyscf.mcscf.CASCI(mf, 6, 6)
 mc.fcisolver.nroots = n_states
 emc = mc.casci()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/nevpt/03-nevpt2-density-fitting.py
+++ b/examples/nevpt/03-nevpt2-density-fitting.py
@@ -31,7 +31,7 @@ weights = np.ones(n_states)/n_states
 mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
@@ -41,6 +41,6 @@ weights = np.ones(n_states)/n_states
 mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights).density_fit('aug-cc-pvdz-ri')
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/nevpt/04-nevpt2_sc_vs_fic.py
+++ b/examples/nevpt/04-nevpt2_sc_vs_fic.py
@@ -33,7 +33,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
 # FIC-NEVPT2 calculation using Prism
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.s_thresh_singles = 1e-10

--- a/examples/nevpt/05-nevpt2-expert-options.py
+++ b/examples/nevpt/05-nevpt2-expert-options.py
@@ -34,7 +34,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
 # Increasing the truncation parameter for linear dependencies
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.s_thresh_singles = 1e-6
@@ -42,7 +42,7 @@ nevpt.s_thresh_doubles = 1e-6
 e_tot, e_corr, osc = nevpt.kernel()
 
 # Including the singles amplitudes in the NEVPT2 energy
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = True
 nevpt.s_thresh_singles = 1e-10
@@ -51,7 +51,7 @@ e_tot, e_corr, osc = nevpt.kernel()
 
 # Selecting reference states
 ref_list = [1,5,6]
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True, select_reference = ref_list)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum', select_reference = ref_list)
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.s_thresh_singles = 1e-10

--- a/examples/nevpt/06-nevpt2-1RDMS.py
+++ b/examples/nevpt/06-nevpt2-1RDMS.py
@@ -45,7 +45,7 @@ mc.analyze()
 print("CASSCF energy: %f\n" % emc)
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.s_thresh_singles = 1e-6
 nevpt.s_thresh_doubles = 1e-6

--- a/examples/nevpt/07-nevpt2-ntos.py
+++ b/examples/nevpt/07-nevpt2-ntos.py
@@ -41,7 +41,7 @@ mc.fcisolver.nroots = n_states
 emc = mc.casci()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 

--- a/examples/nevpt/08-nevpt2-einsum-options.py
+++ b/examples/nevpt/08-nevpt2-einsum-options.py
@@ -1,0 +1,46 @@
+#!/usr/bin/env python
+'''
+NEVPT2 calculation for CH2
+'''
+from pyscf import gto, scf, mcscf
+import prism.interface
+import prism.mr_adc
+import prism.nevpt
+
+mol = gto.M()
+mol.atom = '''
+C   1
+H   1 1.085
+H   1 1.085  2 135.5
+'''
+mol.basis = 'cc-pvdz'
+mol.symmetry = True
+mol.spin = 2
+mol.verbose = 4
+mol.build()
+
+# RHF calculation
+mf = scf.RHF(mol)
+mf.conv_tol = 1e-12
+mf.kernel()
+
+# CASSCF calculation
+mc = mcscf.CASSCF(mf, 14, 6)
+mc.with_dep4 = True
+mc.max_cycle_micro = 10
+mc.kernel()
+
+# NEVPT2 with pytblis
+interface = prism.interface.PYSCF(mf, mc, backend = "pytblis")
+nevpt = prism.nevpt.NEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()
+
+# NEVPT2 with opt_einsum
+interface = prism.interface.PYSCF(mf, mc, backend = "opt_einsum")
+nevpt = prism.nevpt.NEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()
+
+# NEVPT2 with numpy
+interface = prism.interface.PYSCF(mf, mc, backend = "numpy")
+nevpt = prism.nevpt.NEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/qdnevpt/01-qdnevpt2-basic.py
+++ b/examples/qdnevpt/01-qdnevpt2-basic.py
@@ -46,18 +46,18 @@ mc.analyze()
 print("CASSCF energy: %f\n" % emc)
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.method_type = "qd"
 e_tot, e_corr, osc = nevpt.kernel()
 
 # Alternative set up
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
 # QD-NEVPT2 with frozen core
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.nfrozen = 1
 e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/qdnevpt/02-qdnevpt2-density-fitting.py
+++ b/examples/qdnevpt/02-qdnevpt2-density-fitting.py
@@ -31,7 +31,7 @@ weights = np.ones(n_states)/n_states
 mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()
 
@@ -41,6 +41,6 @@ weights = np.ones(n_states)/n_states
 mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights).density_fit('aug-cc-pvdz-ri')
 emc = mc.mc1step()[0]
 
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 e_tot, e_corr, osc = nevpt.kernel()

--- a/examples/qdnevpt/03-qdnevpt2-expert-options.py
+++ b/examples/qdnevpt/03-qdnevpt2-expert-options.py
@@ -34,7 +34,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6).state_average_(weights)
 emc = mc.mc1step()[0]
 
 # Increasing the truncation parameter for linear dependencies
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.s_thresh_singles = 1e-6
@@ -42,7 +42,7 @@ nevpt.s_thresh_doubles = 1e-6
 e_tot, e_cor, oscr = nevpt.kernel()
 
 # Including the singles amplitudes in the QD-NEVPT2 energy
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = True
 nevpt.s_thresh_singles = 1e-8
@@ -51,7 +51,7 @@ e_tot, e_corr, osc = nevpt.kernel()
 
 # Selecting reference states
 ref_list = [1,5,6]
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True, select_reference = ref_list)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum', select_reference = ref_list)
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.s_thresh_singles = 1e-8

--- a/examples/qdnevpt/04-qdnevpt2-1RDMS.py
+++ b/examples/qdnevpt/04-qdnevpt2-1RDMS.py
@@ -45,7 +45,7 @@ mc.analyze()
 print("CASSCF energy: %f\n" % emc)
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.s_thresh_singles = 1e-6
 nevpt.s_thresh_doubles = 1e-6

--- a/examples/qdnevpt/05-qdnevpt2-einsum-options.py
+++ b/examples/qdnevpt/05-qdnevpt2-einsum-options.py
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+'''
+QD-NEVPT calculation for O2
+'''
+from pyscf import gto, scf, mcscf
+import prism.interface
+import prism.nevpt
+
+mol = gto.Mole()
+mol.atom = 'O 0 0 0; O 0 0 1.2'
+mol.spin = 2
+mol.basis = 'ccpvtz'
+mol.verbose = 4
+mol.build()
+
+# RHF calculation
+mf = scf.RHF(mol).density_fit(auxbasis='ccpvtz-jkfit')
+ehf = mf.scf()
+print("SCF energy: %f\n" % ehf)
+
+# MS-CASCI calculation
+from pyscf.mcscf import avas
+mo_coeff = avas.kernel(mf, ['O 2p'], minao=mol.basis)[2]
+
+mc = mcscf.CASCI(mf, 6, 8)
+mc.fcisolver.nroots = 3
+emc = mc.kernel(mo_coeff)[0]
+
+# QD-NEVPT with pytblis
+interface = prism.interface.PYSCF(mf, mc, backend = 'pytblis')
+nevpt = prism.nevpt.QDNEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()
+
+# QD-NEVPT with auto-detection for tensor contraction engine
+interface = prism.interface.PYSCF(mf, mc, backend = None)
+nevpt = prism.nevpt.QDNEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()
+
+# QD-NEVPT with numpy
+interface = prism.interface.PYSCF(mf, mc, backend = 'numpy')
+nevpt = prism.nevpt.QDNEVPT(interface)
+e_tot, e_corr, osc = nevpt.kernel()
+

--- a/examples/soc/01-qdnevpt2-SOC.py
+++ b/examples/soc/01-qdnevpt2-SOC.py
@@ -42,7 +42,7 @@ mc.analyze()
 
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.method = "nevpt2"
 nevpt.method_type = "qd"

--- a/examples/soc/02-qdnevpt2-gtensor.py
+++ b/examples/soc/02-qdnevpt2-gtensor.py
@@ -42,7 +42,7 @@ mc.analyze()
 
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.method = "nevpt2"
 nevpt.method_type = "qd"

--- a/examples/spectrum/01-mr-adc-spectrum.py
+++ b/examples/spectrum/01-mr-adc-spectrum.py
@@ -28,7 +28,7 @@ mc = pyscf.mcscf.CASSCF(mf, 6, 6)
 emc = mc.mc1step()[0]
 
 # CVS-IP-MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.method_type = "cvs-ip"
 mr_adc.ncvs = 2

--- a/examples/spectrum/02-qdnevpt-spectrum.py
+++ b/examples/spectrum/02-qdnevpt-spectrum.py
@@ -46,13 +46,13 @@ mc.analyze()
 print("CASSCF energy: %f\n" % emc)
 
 # QD-NEVPT2 with all electrons correlated
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 e_tot, e_corr, osc_str = nevpt.kernel()
 
 ## For spectrum
 from prism.tools.spectrum import plot
 e_diff = (e_tot[1:] - e_tot[0]) * interface.hartree_to_ev
-plot(e_diff, osc_str, broadening = 0.1, omega_min = 0, omega_max = 15, plot = True, x_label = "Energy, eV", y_label = "Intensity", title = "UV/vis spectrum", filename = "qdnevpt")
+plot(e_diff, osc_str, broadening = 0.1, omega_min = 7, omega_max = 17, plot = True, x_label = "Energy, eV", y_label = "Intensity", title = "UV/vis spectrum", filename = "qdnevpt")
 
 

--- a/interface.py
+++ b/interface.py
@@ -24,6 +24,8 @@ import tempfile
 import numpy as np
 
 import prism.lib.logger as logger
+import prism.lib.numpy_helper as np_helper
+
 class PYSCF:
 
     def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
@@ -230,21 +232,20 @@ class PYSCF:
         self.dip_mom_ao = mf.mol.intor_symmetric("int1e_r", comp = 3)
 
         # Einsum Backend
-        PYSCF.opt_einsum = bool(opt_einsum)
-        PYSCF.pytblis = bool(pytblis)
+        self.opt_einsum = bool(opt_einsum)
+        self.pytblis = bool(pytblis)
 
-        self._einsum = None
-        self.einsum_backend = None
+        self._einsum_backend = None
         self.einsum_type = "greedy"
         self.dot = np.dot
 
+        np_helper.set_einsum(self)
+
     @property
-    def einsum(self):
-        if self._einsum is None:
-            from prism.lib import numpy_helper
-            self._einsum = numpy_helper.einsum
-            self.einsum_backend = numpy_helper.EINSUM_BACKEND
-        return self._einsum
+    def einsum_backend(self):
+        if self._einsum_backend is None:
+            self._einsum_backend = np_helper.einsum_backend(self)
+        return self._einsum_backend
 
     @property
     def with_df(self):

--- a/interface.py
+++ b/interface.py
@@ -24,6 +24,8 @@ import tempfile
 import numpy as np
 
 import prism.lib.logger as logger
+import prism.lib.numpy_helper as np_helper
+
 class PYSCF:
 
     def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
@@ -245,21 +247,20 @@ class PYSCF:
         self.dip_mom_ao = mf.mol.intor_symmetric("int1e_r", comp = 3)
 
         # Einsum Backend
-        PYSCF.opt_einsum = bool(opt_einsum)
-        PYSCF.pytblis = bool(pytblis)
+        self.opt_einsum = bool(opt_einsum)
+        self.pytblis = bool(pytblis)
 
-        self._einsum = None
-        self.einsum_backend = None
+        self._einsum_backend = None
         self.einsum_type = "greedy"
         self.dot = np.dot
 
+        np_helper.set_einsum(self)
+
     @property
-    def einsum(self):
-        if self._einsum is None:
-            from prism.lib import numpy_helper
-            self._einsum = numpy_helper.einsum
-            self.einsum_backend = numpy_helper.EINSUM_BACKEND
-        return self._einsum
+    def einsum_backend(self):
+        if self._einsum_backend is None:
+            self._einsum_backend = np_helper.einsum_backend(self)
+        return self._einsum_backend
 
         # Molden helper
         from pyscf.tools import molden

--- a/interface.py
+++ b/interface.py
@@ -28,7 +28,7 @@ import prism.lib.numpy_helper as np_helper
 
 class PYSCF:
 
-    def __init__(self, mf, mc = None, einsum_backend = None, select_reference = None):
+    def __init__(self, mf, mc = None, backend = None, select_reference = None):
 
         self.stdout = mf.stdout
         if mc is None:
@@ -236,12 +236,12 @@ class PYSCF:
         self.molden = molden
 
         # Einsum Backend
-        if einsum_backend not in ("opt_einsum", "pytblis", "numpy", None):
+        if backend not in ("opt_einsum", "pytblis", "numpy", None):
             msg = (f"Requested einsum backend '{einsum_backend}' is unknown. "
                     "Valid backend options are: 'opt_einsum', 'pytblis', 'numpy', or None.")
             raise ValueError(msg)
 
-        self._einsum_backend = np_helper.einsum_backend(einsum_backend, self.log)
+        self._einsum_backend = np_helper.einsum_backend(backend, self.log)
         self.einsum_type = "greedy"
         self.dot = np.dot
 

--- a/interface.py
+++ b/interface.py
@@ -28,7 +28,7 @@ import prism.lib.numpy_helper as np_helper
 
 class PYSCF:
 
-    def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
+    def __init__(self, mf, mc = None, einsum_backend = None, select_reference = None):
 
         self.stdout = mf.stdout
         if mc is None:
@@ -236,22 +236,17 @@ class PYSCF:
         self.molden = molden
 
         # Einsum Backend
-        if not isinstance(opt_einsum, bool):
-            raise TypeError(f"opt_einsum must be bool, got {type(opt_einsum).__name__}")
-        if not isinstance(pytblis, bool):
-            raise TypeError(f"pytblis must be bool, got {type(pytblis).__name__}")
+        if einsum_backend not in ("opt_einsum", "pytblis", "numpy", None):
+            msg = (f"Requested einsum backend '{einsum_backend}' is unknown. "
+                    "Valid backend options are: 'opt_einsum', 'pytblis', 'numpy', or None.")
+            raise ValueError(msg)
 
-        self.opt_einsum = opt_einsum
-        self.pytblis = pytblis
-
-        self._einsum_backend = None
+        self._einsum_backend = np_helper.einsum_backend(einsum_backend, self.log)
         self.einsum_type = "greedy"
         self.dot = np.dot
 
     @property
     def einsum_backend(self):
-        if self._einsum_backend is None:
-            self._einsum_backend = np_helper.einsum_backend(self.opt_einsum, self.pytblis, self.log)
         return self._einsum_backend
 
     def einsum(self, scripts, *tensors, **kwargs):

--- a/interface.py
+++ b/interface.py
@@ -30,11 +30,10 @@ class PYSCF:
 
     def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
 
+        self.stdout = mf.stdout
         if mc is None:
-            self.stdout = mf.stdout
             self.verbose = mf.verbose
         else:
-            self.stdout = mf.stdout
             self.verbose = mc.verbose
 
         log = logger.Logger(self.stdout, self.verbose)
@@ -44,6 +43,7 @@ class PYSCF:
 
         from pyscf import lib
         self.type = "pyscf"
+        self.log = log
 
         # General info
         self.mol = mf.mol
@@ -52,7 +52,6 @@ class PYSCF:
         self.e_scf = mf.e_tot
         self.mf = mf
         self.mc = mc
-        self.log = log
 
         # Unit conversions
         self.hartree_to_ev = 27.2113862459817
@@ -74,10 +73,7 @@ class PYSCF:
             self.symmetry = mf.mol.symmetry
             self.e_ref = [mf.e_tot]
 
-            if getattr(mf, 'with_df', None):
-                self.reference_df = mf.with_df
-            else:
-                self.reference_df = None
+            self.reference_df = getattr(mf, "with_df", None)
 
             if self.symmetry:
                 from pyscf import symm
@@ -97,12 +93,12 @@ class PYSCF:
             ci = mc.ci.copy()
 
             if isinstance(mc, CASCI):
-                if isinstance(ci, (list)):
+                if isinstance(ci, list):
                     self.reference = "ms-casci"
                 else:
                     self.reference = "casci"
             else:
-                if(hasattr(mc, 'weights') == True and isinstance(mc.ci, (list))):
+                if hasattr(mc, 'weights') and isinstance(mc.ci, list):
                     self.weights = mc.weights
                     self.reference = "sa-casscf"
                 else:
@@ -113,25 +109,17 @@ class PYSCF:
             if self.reference == "sa-casscf":
                 e_fzc = e_ref - e_cas
                 e_ref = mc.e_states
-                e_cas = []
-                for p in range(len(e_ref)):
-                    e_cas.append(e_ref[p]-e_fzc)
+                e_cas = [e - e_fzc for e in e_ref]
             elif self.reference in ("casscf", "casci"):
                 e_ref = [e_ref]
                 e_cas = [e_cas]
                 ci = [ci]
 
             if select_reference is not None:
-                e_ref_copy = []
-                e_cas_copy = []
-                ci_copy = []
-                for state in select_reference:
-                    e_ref_copy.append(e_ref[state-1])
-                    e_cas_copy.append(e_cas[state-1])
-                    ci_copy.append(ci[state-1])
-                e_ref = e_ref_copy
-                e_cas = e_cas_copy
-                ci = ci_copy
+                state_idx = [state-1 for state in select_reference]
+                e_ref = [e_ref[i] for i in state_idx]
+                e_cas = [e_cas[i] for i in state_idx]
+                ci = [ci[i] for i in state_idx]
                 log.info("\nReference states selected: %s" % str(select_reference))
 
             self.max_memory = mc.max_memory
@@ -156,10 +144,7 @@ class PYSCF:
             self.xmol = None
             self.contr_coeff = None
 
-            if getattr(mc, 'with_df', None):
-                self.reference_df = mc.with_df
-            else:
-                self.reference_df = None
+            self.reference_df = getattr(mc, "with_df", None)
 
             # Compute state-averaged 1-RDM with respect to the reference manifold
             ref_rdm1 = np.zeros((mc.ncas, mc.ncas))
@@ -265,7 +250,6 @@ class PYSCF:
         if self._einsum_backend is None:
             self._einsum_backend = np_helper.einsum_backend(self)
         return self._einsum_backend
-
 
     @property
     def with_df(self):

--- a/interface.py
+++ b/interface.py
@@ -248,13 +248,17 @@ class PYSCF:
         self.einsum_type = "greedy"
         self.dot = np.dot
 
-        np_helper.set_einsum(self)
-
     @property
     def einsum_backend(self):
         if self._einsum_backend is None:
             self._einsum_backend = np_helper.einsum_backend(self.opt_einsum, self.pytblis, self.log)
         return self._einsum_backend
+
+    def einsum(self, scripts, *tensors, **kwargs):
+        return np_helper.einsum(scripts, *tensors, backend=self.einsum_backend, **kwargs)
+
+    def contract(self, subscripts, A, B, **kwargs):
+        return np_helper.contract(subscripts, A, B, backend=self.einsum_backend, **kwargs)
 
     @property
     def with_df(self):

--- a/interface.py
+++ b/interface.py
@@ -253,7 +253,7 @@ class PYSCF:
     @property
     def einsum_backend(self):
         if self._einsum_backend is None:
-            self._einsum_backend = np_helper.einsum_backend(self)
+            self._einsum_backend = np_helper.einsum_backend(self.opt_einsum, self.pytblis, self.log)
         return self._einsum_backend
 
     @property

--- a/interface.py
+++ b/interface.py
@@ -15,7 +15,9 @@
 #
 # Authors: Carlos E. V. de Moura <carlosevmoura@gmail.com>
 #          Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
-#          James D. Serna <jserna456@gmail.com>
+#                  Ilia M. Mazin <ilia.mazin@gmail.com>
+#              Donna H. Odhiambo <donna.odhiambo@proton.me>
+#                 James D. Serna <jserna456@gmail.com>
 
 import os
 import tempfile
@@ -24,7 +26,7 @@ import numpy as np
 import prism.lib.logger as logger
 class PYSCF:
 
-    def __init__(self, mf, mc = None, opt_einsum = False, select_reference = None):
+    def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
 
         if mc is None:
             self.stdout = mf.stdout
@@ -51,7 +53,6 @@ class PYSCF:
 
         # Unit conversions
         self.hartree_to_ev = 27.2113862459817
-#        self.hartree_to_ev = 27.2114
         self.hartree_to_inv_cm = 219474.63136314
 
         log.info("Collecting reference wavefunction information...")
@@ -177,7 +178,10 @@ class PYSCF:
 # Removing the spin manifold code for now
 
             # Print reference info
-            self.ref_wfn_spin_mult = self.print_reference_info(ci, self.ncas, mc.nelecas, e_ref, e_cas)
+            if self.ncas > 0:
+                self.ref_wfn_spin_mult = self.print_reference_info(ci, self.ncas, mc.nelecas, e_ref, e_cas)
+            else:
+                self.ref_wfn_spin_mult = [1]
 
             self.ref_wfn = ci
             self.ref_nelecas = len(ci) * [mc.nelecas, ]
@@ -225,14 +229,22 @@ class PYSCF:
         # Dipole moments
         self.dip_mom_ao = mf.mol.intor_symmetric("int1e_r", comp = 3)
 
-        # Whether to use opt_einsum
-        if opt_einsum:
-            from opt_einsum import contract
-            self.einsum = contract
-            self.einsum_type = "greedy"
-        else:
-            self.einsum = np.einsum
-            self.einsum_type = "greedy"
+        # Einsum Backend
+        PYSCF.opt_einsum = bool(opt_einsum)
+        PYSCF.pytblis = bool(pytblis)
+
+        self._einsum = None
+        self.einsum_backend = None
+        self.einsum_type = "greedy"
+        self.dot = np.dot
+
+    @property
+    def einsum(self):
+        if self._einsum is None:
+            from prism.lib import numpy_helper
+            self._einsum = numpy_helper.einsum
+            self.einsum_backend = numpy_helper.EINSUM_BACKEND
+        return self._einsum
 
     @property
     def with_df(self):

--- a/interface.py
+++ b/interface.py
@@ -15,7 +15,9 @@
 #
 # Authors: Carlos E. V. de Moura <carlosevmoura@gmail.com>
 #          Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
-#          James D. Serna <jserna456@gmail.com>
+#                  Ilia M. Mazin <ilia.mazin@gmail.com>
+#              Donna H. Odhiambo <donna.odhiambo@proton.me>
+#                 James D. Serna <jserna456@gmail.com>
 
 import os
 import tempfile
@@ -24,7 +26,7 @@ import numpy as np
 import prism.lib.logger as logger
 class PYSCF:
 
-    def __init__(self, mf, mc = None, opt_einsum = False, select_reference = None):
+    def __init__(self, mf, mc = None, opt_einsum = False, pytblis = False, select_reference = None):
 
         if mc is None:
             self.stdout = mf.stdout
@@ -189,7 +191,10 @@ class PYSCF:
 # Removing the spin manifold code for now
 
             # Print reference info
-            self.ref_wfn_spin_mult = self.print_reference_info(ci, self.ncas, mc.nelecas, e_ref, e_cas)
+            if self.ncas > 0:
+                self.ref_wfn_spin_mult = self.print_reference_info(ci, self.ncas, mc.nelecas, e_ref, e_cas)
+            else:
+                self.ref_wfn_spin_mult = [1]
 
             self.ref_wfn = ci
             self.ref_nelecas = len(ci) * [mc.nelecas, ]
@@ -239,14 +244,22 @@ class PYSCF:
         # Dipole moments
         self.dip_mom_ao = mf.mol.intor_symmetric("int1e_r", comp = 3)
 
-        # Whether to use opt_einsum
-        if opt_einsum:
-            from opt_einsum import contract
-            self.einsum = contract
-            self.einsum_type = "greedy"
-        else:
-            self.einsum = np.einsum
-            self.einsum_type = "greedy"
+        # Einsum Backend
+        PYSCF.opt_einsum = bool(opt_einsum)
+        PYSCF.pytblis = bool(pytblis)
+
+        self._einsum = None
+        self.einsum_backend = None
+        self.einsum_type = "greedy"
+        self.dot = np.dot
+
+    @property
+    def einsum(self):
+        if self._einsum is None:
+            from prism.lib import numpy_helper
+            self._einsum = numpy_helper.einsum
+            self.einsum_backend = numpy_helper.EINSUM_BACKEND
+        return self._einsum
 
         # Molden helper
         from pyscf.tools import molden

--- a/interface.py
+++ b/interface.py
@@ -246,6 +246,10 @@ class PYSCF:
         # Dipole moments
         self.dip_mom_ao = mf.mol.intor_symmetric("int1e_r", comp = 3)
 
+        # Molden helper
+        from pyscf.tools import molden
+        self.molden = molden
+
         # Einsum Backend
         self.opt_einsum = bool(opt_einsum)
         self.pytblis = bool(pytblis)
@@ -262,9 +266,6 @@ class PYSCF:
             self._einsum_backend = np_helper.einsum_backend(self)
         return self._einsum_backend
 
-        # Molden helper
-        from pyscf.tools import molden
-        self.molden = molden
 
     @property
     def with_df(self):

--- a/interface.py
+++ b/interface.py
@@ -236,8 +236,13 @@ class PYSCF:
         self.molden = molden
 
         # Einsum Backend
-        self.opt_einsum = bool(opt_einsum)
-        self.pytblis = bool(pytblis)
+        if not isinstance(opt_einsum, bool):
+            raise TypeError(f"opt_einsum must be bool, got {type(opt_einsum).__name__}")
+        if not isinstance(pytblis, bool):
+            raise TypeError(f"pytblis must be bool, got {type(pytblis).__name__}")
+
+        self.opt_einsum = opt_einsum
+        self.pytblis = pytblis
 
         self._einsum_backend = None
         self.einsum_type = "greedy"

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -3,7 +3,6 @@
 Extension to numpy
 '''
 import numpy
-from prism.interface import PYSCF
 from functools import lru_cache
 
 dot = numpy.dot
@@ -11,10 +10,6 @@ asarray = numpy.asarray
 
 ##TODO: create attribute for user defined flop threshold
 FLOP_THRESHOLD = 5e6
-
-# Interface flags
-PYTBLIS = getattr(PYSCF, 'pytblis', False)
-OPT_EINSUM = getattr(PYSCF, 'opt_einsum', False)
 
 # Detect backends
 def _has_module(name):
@@ -24,30 +19,45 @@ def _has_module(name):
     except (ImportError, OSError):
         return False
 
-_HAS_PYTBLIS = _has_module('pytblis')
-_HAS_OPT_EINSUM = _has_module('opt_einsum')
+def einsum_backend(PYSCF):
+    # Interface flags
+    PYTBLIS = getattr(PYSCF, 'pytblis', False)
+    OPT_EINSUM = getattr(PYSCF, 'opt_einsum', False)
 
-# Backend priority: provided flags > pytblis > opt_einsum > numpy fallback
-if OPT_EINSUM and _HAS_OPT_EINSUM:
-    EINSUM_BACKEND = "opt_einsum"
-elif PYTBLIS and _HAS_PYTBLIS:
-    EINSUM_BACKEND = "pytblis"
-elif  _HAS_PYTBLIS:
-    EINSUM_BACKEND = "pytblis"
-elif _HAS_OPT_EINSUM:
-    EINSUM_BACKEND = "opt_einsum"
-else:
-    EINSUM_BACKEND = "numpy"
+    _HAS_PYTBLIS = _has_module('pytblis')
+    _HAS_OPT_EINSUM = _has_module('opt_einsum')
+
+    # Backend priority: provided flags > pytblis > opt_einsum > numpy fallback
+    if OPT_EINSUM and _HAS_OPT_EINSUM:
+        EINSUM_BACKEND = "opt_einsum"
+    elif PYTBLIS and _HAS_PYTBLIS:
+        EINSUM_BACKEND = "pytblis"
+    elif  _HAS_PYTBLIS:
+        EINSUM_BACKEND = "pytblis"
+    elif _HAS_OPT_EINSUM:
+        EINSUM_BACKEND = "opt_einsum"
+    else:
+        EINSUM_BACKEND = "numpy"
+
+    log = PYSCF.log
+    if OPT_EINSUM and EINSUM_BACKEND != "opt_einsum":
+        log.info(
+            "opt_einsum was requested (OPT_EINSUM=True) but is not available. "
+            "Falling back to %s.", EINSUM_BACKEND
+        )
+    if PYTBLIS and EINSUM_BACKEND != "pytblis":
+        log.info(
+            "pytblis was requested (PYTBLIS=True) but is not available. "
+            "Falling back to %s.", EINSUM_BACKEND
+        )
+
+    return EINSUM_BACKEND
 
 # Import backend
 try:
-    if EINSUM_BACKEND == "pytblis":
-        import pytblis
-    elif EINSUM_BACKEND == "opt_einsum":
-        import opt_einsum
+    import pytblis
 except Exception:
-    EINSUM_BACKEND = "numpy"
-
+    import opt_einsum
 _numpy_einsum = numpy.einsum
 
 try:
@@ -60,7 +70,7 @@ except ImportError:
 def _compiled_opt_expr(subscripts, shapes, optimize):
     return _opt_einsum.contract_expression(subscripts, *shapes, optimize=optimize)
 
-def contract(subscripts, A, B, **kwargs):
+def contract(self, subscripts, A, B, **kwargs):
     '''
     Perform tensor contraction using einsum notation
     C = alpha * einsum(subscripts, A, B) + beta * C
@@ -73,7 +83,10 @@ def contract(subscripts, A, B, **kwargs):
         out : ndarray, optional
             Output tensor to store the result.
     '''
+    EINSUM_BACKEND = self.einsum_backend
+
     idx_str = subscripts.replace(" ","")
+
     # Call numpy.asarray because A or B may be HDF5 Datasets
     A, B = asarray(A), asarray(B)
 
@@ -169,7 +182,7 @@ def contract(subscripts, A, B, **kwargs):
     out_arr[...] = Cres
     return out
 
-def einsum(scripts, *tensors, **kwargs):
+def einsum(self, scripts, *tensors, **kwargs):
     '''
     Perform a more efficient einsum via reshaping to a matrix multiply.
 
@@ -178,6 +191,8 @@ def einsum(scripts, *tensors, **kwargs):
     and appears only twice (i.e. no 'ij,ik,il->jkl'). The output indices must
     be explicitly specified (i.e. 'ij,j->i' and not 'ij,j').
     '''
+    EINSUM_BACKEND = self.einsum_backend
+
     subscripts = scripts.replace(" ","")
     tensors = tuple(asarray(t) for t in tensors)
 
@@ -198,7 +213,7 @@ def einsum(scripts, *tensors, **kwargs):
 
     _contract = kwargs.pop('_contract', contract)
     if len(tensors) <= 2:
-        return _contract(subscripts, *tensors, **kwargs)
+        return _contract(self, subscripts, *tensors, **kwargs)
 
     _, contraction_list = _einsum_path(subscripts, *tensors, optimize=optimize, einsum_call=True)
 
@@ -211,8 +226,10 @@ def einsum(scripts, *tensors, **kwargs):
         else:
             inds, _, einsum_str, _, _ = contraction
         ops = [operands[i] for i in inds]
-        fn = _contract if len(ops) == 2 else _numpy_einsum
-        result = fn(einsum_str, *ops, **kwargs)
+        if len(ops)==2:
+            result = _contract(self, einsum_str, *ops, **kwargs)
+        else:
+            result = _numpy_einsum(einsum_str, *ops, **kwargs)
         operands = [op for i, op in enumerate(operands) if i not in inds]
         operands.append(result)
         del ops, result
@@ -283,3 +300,15 @@ def _analyze_indices(idx_str):
     permC = [out_idx.index(i) for i in idxC]
 
     return idxA, idxB, idxC, orderA, orderB, permC, shared
+
+def set_einsum(PYSCF):
+    import types
+
+    if not hasattr(PYSCF, 'einsum_backend'):
+        raise AttributeError(
+            f"Expected object with 'einsum_backend' attribute, "
+            f"got {type(PYSCF).__name__}"
+        )
+    PYSCF.einsum = types.MethodType(einsum, PYSCF)
+    PYSCF.contract = types.MethodType(contract, PYSCF)
+

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -10,7 +10,6 @@ dot = numpy.dot
 asarray = numpy.asarray
 
 ##TODO: create attribute for user defined flop threshold
-#FLOP_THRESHOLD = 1e4
 FLOP_THRESHOLD = 5e6
 
 # Interface flags
@@ -44,8 +43,6 @@ else:
 try:
     if EINSUM_BACKEND == "pytblis":
         import pytblis
-        ## TODO: fine tune values for thread control
-        pytblis.set_num_threads(8)
     elif EINSUM_BACKEND == "opt_einsum":
         import opt_einsum
 except Exception:

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -5,7 +5,6 @@ Extension to numpy
 import numpy
 from functools import lru_cache
 
-dot = numpy.dot
 asarray = numpy.asarray
 
 ##TODO: create attribute for user defined flop threshold
@@ -49,15 +48,15 @@ def einsum_backend(opt_einsum, pytblis, log):
 
 # Import backend
 try:
-    import pytblis
-except Exception:
-    import opt_einsum
-_numpy_einsum = numpy.einsum
+    import pytblis as _pytblis
+except ImportError:
+    _pytblis = None
 
 try:
     import opt_einsum as _opt_einsum
     _einsum_path = getattr(_opt_einsum, "contract_path", numpy.einsum_path)
 except ImportError:
+    _opt_einsum = None
     _einsum_path = getattr(numpy, "einsum_path", None)
 
 @lru_cache(maxsize=256)
@@ -68,7 +67,6 @@ def contract(subscripts, A, B, backend, **kwargs):
     '''
     Perform tensor contraction using einsum notation
     C = alpha * einsum(subscripts, A, B) + beta * C
-
     Kwargs:
         alpha : scalar, optional
             Default value is 1.
@@ -90,7 +88,7 @@ def contract(subscripts, A, B, backend, **kwargs):
     #    return expr(A, B, **kwargs)
 
     if backend == "pytblis":
-       return pytblis.contract(idx_str, A, B, **kwargs)
+       return _pytblis.contract(idx_str, A, B, **kwargs)
 
     # Linear algebra kwargs
     alpha = kwargs.pop('alpha', 1)
@@ -99,12 +97,12 @@ def contract(subscripts, A, B, backend, **kwargs):
 
     # check: binary einsum with an explicit output?
     if "->" not in idx_str or idx_str.count(",") != 1:
-        return _numpy_einsum(idx_str, A, B, **kwargs)
+        return numpy.einsum(idx_str, A, B, **kwargs)
 
     # check: valid GEMM contraction?
     analysis = _analyze_indices(idx_str)
     if analysis is None:
-        return _numpy_einsum(idx_str, A, B, **kwargs)
+        return numpy.einsum(idx_str, A, B, **kwargs)
 
     idxA, idxB, idxC, orderA, orderB, permC, shared = analysis
 
@@ -119,7 +117,7 @@ def contract(subscripts, A, B, backend, **kwargs):
 
     # check: dimensions valid?
     if len(idxA) != A.ndim or len(idxB) != B.ndim:
-        return _numpy_einsum(idx_str, A, B, **kwargs)
+        return numpy.einsum(idx_str, A, B, **kwargs)
 
     shapeA = dict(zip(idxA, A.shape))
     shapeB = dict(zip(idxB, B.shape))
@@ -139,7 +137,7 @@ def contract(subscripts, A, B, backend, **kwargs):
 
     # check: FLOP threshold met?
     if flops < FLOP_THRESHOLD:
-        return _numpy_einsum(idx_str, A, B, **kwargs)
+        return numpy.einsum(idx_str, A, B, **kwargs)
 
     At = A.transpose(orderA).reshape(-1, inner_dim)
     Bt = B.transpose(orderB).reshape(inner_dim, -1)
@@ -149,7 +147,7 @@ def contract(subscripts, A, B, backend, **kwargs):
     if not Bt.flags.c_contiguous:
         Bt = asarray(Bt, order="C")
 
-    Cmat = dot(At, Bt)
+    Cmat = numpy.dot(At, Bt)
 
     out_shape = (
         [shapeA[i] for i in idxA if i not in shared] +
@@ -187,12 +185,12 @@ def einsum(scripts, *tensors, backend, **kwargs):
     tensors = tuple(asarray(t) for t in tensors)
 
     if len(tensors) <= 1 or '...' in subscripts:
-        return _numpy_einsum(subscripts, *tensors, **kwargs)
+        return numpy.einsum(subscripts, *tensors, **kwargs)
 
     if backend == "pytblis" and len(tensors) < 4:
         if kwargs.get("optimize") is True:
            kwargs["optimize"] = "optimal"
-        return pytblis.einsum(subscripts, *tensors, **kwargs)
+        return _pytblis.einsum(subscripts, *tensors, **kwargs)
 
     optimize = kwargs.pop('optimize', True)
     if backend == "opt_einsum":
@@ -218,7 +216,7 @@ def einsum(scripts, *tensors, backend, **kwargs):
         if len(ops)==2:
             result = _contract(einsum_str, *ops, backend=backend, **kwargs)
         else:
-            result = _numpy_einsum(einsum_str, *ops, **kwargs)
+            result = numpy.einsum(einsum_str, *ops, **kwargs)
         operands = [op for i, op in enumerate(operands) if i not in inds]
         operands.append(result)
         del ops, result

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -19,39 +19,33 @@ def _has_module(name):
     except (ImportError, OSError):
         return False
 
-def einsum_backend(PYSCF):
-    # Interface flags
-    PYTBLIS = getattr(PYSCF, 'pytblis', False)
-    OPT_EINSUM = getattr(PYSCF, 'opt_einsum', False)
+def einsum_backend(opt_einsum, pytblis, log):
 
-    _HAS_PYTBLIS = _has_module('pytblis')
-    _HAS_OPT_EINSUM = _has_module('opt_einsum')
+    has_pytblis = _has_module("pytblis")
+    has_opt_einsum = _has_module("opt_einsum")
 
     # Backend priority: provided flags > pytblis > opt_einsum > numpy fallback
-    if OPT_EINSUM and _HAS_OPT_EINSUM:
-        EINSUM_BACKEND = "opt_einsum"
-    elif PYTBLIS and _HAS_PYTBLIS:
-        EINSUM_BACKEND = "pytblis"
-    elif  _HAS_PYTBLIS:
-        EINSUM_BACKEND = "pytblis"
-    elif _HAS_OPT_EINSUM:
-        EINSUM_BACKEND = "opt_einsum"
+    if opt_einsum and has_opt_einsum:
+        backend = "opt_einsum"
+    elif has_pytblis:
+        backend = "pytblis"
+    elif has_opt_einsum:
+        backend = "opt_einsum"
     else:
-        EINSUM_BACKEND = "numpy"
+        backend = "numpy"
 
-    log = PYSCF.log
-    if OPT_EINSUM and EINSUM_BACKEND != "opt_einsum":
-        log.info(
+    if opt_einsum and backend != "opt_einsum":
+        log.warn(
             "opt_einsum was requested (OPT_EINSUM=True) but is not available. "
-            "Falling back to %s.", EINSUM_BACKEND
+            "Falling back to %s.", backend
         )
-    if PYTBLIS and EINSUM_BACKEND != "pytblis":
-        log.info(
+    if pytblis and backend != "pytblis":
+        log.warn(
             "pytblis was requested (PYTBLIS=True) but is not available. "
-            "Falling back to %s.", EINSUM_BACKEND
+            "Falling back to %s.", backend
         )
 
-    return EINSUM_BACKEND
+    return backend
 
 # Import backend
 try:

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -18,33 +18,35 @@ def _has_module(name):
     except (ImportError, OSError):
         return False
 
-def einsum_backend(opt_einsum, pytblis, log):
-
+def einsum_backend(request, log):
+    '''
+    Specify einsum backend from either user request or auto-detection.
+    Available options: opt_einsum, pytblis, and numpy.
+    Backend priority for auto-detection is pytblis > opt_einsum > numpy.
+    '''
     has_pytblis = _has_module("pytblis")
     has_opt_einsum = _has_module("opt_einsum")
 
-    # Backend priority: provided flags > pytblis > opt_einsum > numpy fallback
-    if opt_einsum and has_opt_einsum:
-        backend = "opt_einsum"
-    elif has_pytblis:
-        backend = "pytblis"
+    _options = {
+        "pytblis": has_pytblis,
+        "opt_einsum": has_opt_einsum,
+        "numpy": True
+    }
+
+    if request is not None:
+        if _options[request]:
+            return request
+        log.warn(
+             "%s was requested but is not available. "
+             "Falling back to auto-detection.", request
+         )
+
+    if has_pytblis:
+        return "pytblis"
     elif has_opt_einsum:
-        backend = "opt_einsum"
+        return "opt_einsum"
     else:
-        backend = "numpy"
-
-    if opt_einsum and backend != "opt_einsum":
-        log.warn(
-            "opt_einsum was requested (OPT_EINSUM=True) but is not available. "
-            "Falling back to %s.", backend
-        )
-    if pytblis and backend != "pytblis":
-        log.warn(
-            "pytblis was requested (PYTBLIS=True) but is not available. "
-            "Falling back to %s.", backend
-        )
-
-    return backend
+        return "numpy"
 
 # Import backend
 try:

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -59,7 +59,7 @@ except ImportError:
     _opt_einsum = None
     _einsum_path = getattr(numpy, "einsum_path", None)
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=None)
 def _compiled_opt_expr(subscripts, shapes, optimize):
     return _opt_einsum.contract_expression(subscripts, *shapes, optimize=optimize)
 

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -224,7 +224,7 @@ def einsum(scripts, *tensors, backend, **kwargs):
 
     return operands[0]
 
-@lru_cache(maxsize=256)
+@lru_cache(maxsize=None)
 def _analyze_indices(idx_str):
     '''
     Analyze an einsum index string of the form 'ab,bc->ac'.

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -160,7 +160,7 @@ def contract(subscripts, A, B, backend, **kwargs):
 
     # alpha/beta/out semantics
     if out is None:
-        return Cres * alpha if alpha != 1 else Cres
+        return Cres * alpha if alpha != 1 else Cres.copy()
 
     # out provided
     out_arr = asarray(out)
@@ -169,7 +169,7 @@ def contract(subscripts, A, B, backend, **kwargs):
         numpy.add(Cres, out_arr * beta, out=Cres)
     # assign to output
     out_arr[...] = Cres
-    return out
+    return out_arr
 
 def einsum(scripts, *tensors, backend, **kwargs):
     '''
@@ -186,7 +186,7 @@ def einsum(scripts, *tensors, backend, **kwargs):
     if len(tensors) <= 1 or '...' in subscripts:
         return numpy.einsum(subscripts, *tensors, **kwargs)
 
-    if backend == "pytblis" and len(tensors) < 4:
+    if backend == "pytblis":
         if kwargs.get("optimize") is True:
            kwargs["optimize"] = "optimal"
         return _pytblis.einsum(subscripts, *tensors, **kwargs)

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -64,7 +64,7 @@ except ImportError:
 def _compiled_opt_expr(subscripts, shapes, optimize):
     return _opt_einsum.contract_expression(subscripts, *shapes, optimize=optimize)
 
-def contract(self, subscripts, A, B, **kwargs):
+def contract(subscripts, A, B, backend, **kwargs):
     '''
     Perform tensor contraction using einsum notation
     C = alpha * einsum(subscripts, A, B) + beta * C
@@ -77,8 +77,6 @@ def contract(self, subscripts, A, B, **kwargs):
         out : ndarray, optional
             Output tensor to store the result.
     '''
-    EINSUM_BACKEND = self.einsum_backend
-
     idx_str = subscripts.replace(" ","")
 
     # Call numpy.asarray because A or B may be HDF5 Datasets
@@ -91,7 +89,7 @@ def contract(self, subscripts, A, B, **kwargs):
     #    expr = _compiled_opt_expr(idx_str, shapes, optimize)
     #    return expr(A, B, **kwargs)
 
-    if EINSUM_BACKEND == "pytblis":
+    if backend == "pytblis":
        return pytblis.contract(idx_str, A, B, **kwargs)
 
     # Linear algebra kwargs
@@ -176,7 +174,7 @@ def contract(self, subscripts, A, B, **kwargs):
     out_arr[...] = Cres
     return out
 
-def einsum(self, scripts, *tensors, **kwargs):
+def einsum(scripts, *tensors, backend, **kwargs):
     '''
     Perform a more efficient einsum via reshaping to a matrix multiply.
 
@@ -185,29 +183,26 @@ def einsum(self, scripts, *tensors, **kwargs):
     and appears only twice (i.e. no 'ij,ik,il->jkl'). The output indices must
     be explicitly specified (i.e. 'ij,j->i' and not 'ij,j').
     '''
-    EINSUM_BACKEND = self.einsum_backend
-
     subscripts = scripts.replace(" ","")
     tensors = tuple(asarray(t) for t in tensors)
 
     if len(tensors) <= 1 or '...' in subscripts:
         return _numpy_einsum(subscripts, *tensors, **kwargs)
 
-    #if EINSUM_BACKEND == "pytblis":
-    if EINSUM_BACKEND == "pytblis" and len(tensors) < 4:
+    if backend == "pytblis" and len(tensors) < 4:
         if kwargs.get("optimize") is True:
            kwargs["optimize"] = "optimal"
         return pytblis.einsum(subscripts, *tensors, **kwargs)
 
     optimize = kwargs.pop('optimize', True)
-    if EINSUM_BACKEND == "opt_einsum":
+    if backend == "opt_einsum":
         shapes = tuple(tuple(t.shape) for t in tensors)
         expr = _compiled_opt_expr(subscripts, shapes, optimize)
         return expr(*tensors)
 
     _contract = kwargs.pop('_contract', contract)
     if len(tensors) <= 2:
-        return _contract(self, subscripts, *tensors, **kwargs)
+        return _contract(subscripts, *tensors, backend=backend, **kwargs)
 
     _, contraction_list = _einsum_path(subscripts, *tensors, optimize=optimize, einsum_call=True)
 
@@ -221,7 +216,7 @@ def einsum(self, scripts, *tensors, **kwargs):
             inds, _, einsum_str, _, _ = contraction
         ops = [operands[i] for i in inds]
         if len(ops)==2:
-            result = _contract(self, einsum_str, *ops, **kwargs)
+            result = _contract(einsum_str, *ops, backend=backend, **kwargs)
         else:
             result = _numpy_einsum(einsum_str, *ops, **kwargs)
         operands = [op for i, op in enumerate(operands) if i not in inds]
@@ -241,7 +236,6 @@ def _analyze_indices(idx_str):
         permC
         shared
     '''
-
     # Split the strings into a list of idx char's
     try:
         idxA, idxBC = idx_str.split(",")
@@ -294,15 +288,3 @@ def _analyze_indices(idx_str):
     permC = [out_idx.index(i) for i in idxC]
 
     return idxA, idxB, idxC, orderA, orderB, permC, shared
-
-def set_einsum(PYSCF):
-    import types
-
-    if not hasattr(PYSCF, 'einsum_backend'):
-        raise AttributeError(
-            f"Expected object with 'einsum_backend' attribute, "
-            f"got {type(PYSCF).__name__}"
-        )
-    PYSCF.einsum = types.MethodType(einsum, PYSCF)
-    PYSCF.contract = types.MethodType(contract, PYSCF)
-

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -80,12 +80,11 @@ def contract(subscripts, A, B, backend, **kwargs):
     # Call numpy.asarray because A or B may be HDF5 Datasets
     A, B = asarray(A), asarray(B)
 
-    #optimize = kwargs.pop('optimize', True)
-    #if EINSUM_BACKEND == "opt_einsum":
-    #    # compile/reuse cache expression keyed by shapes + optimize
-    #    shapes = (tuple(A.shape), tuple(B.shape))
-    #    expr = _compiled_opt_expr(idx_str, shapes, optimize)
-    #    return expr(A, B, **kwargs)
+    if backend == "opt_einsum":
+        optimize = kwargs.pop('optimize', True)
+        shapes = (tuple(A.shape), tuple(B.shape))
+        expr = _compiled_opt_expr(idx_str, shapes, optimize)
+        return expr(A, B, **kwargs)
 
     if backend == "pytblis":
        return _pytblis.contract(idx_str, A, B, **kwargs)

--- a/lib/numpy_helper.py
+++ b/lib/numpy_helper.py
@@ -1,0 +1,288 @@
+#!/usr/bin/env python
+'''
+Extension to numpy
+'''
+import numpy
+from prism.interface import PYSCF
+from functools import lru_cache
+
+dot = numpy.dot
+asarray = numpy.asarray
+
+##TODO: create attribute for user defined flop threshold
+#FLOP_THRESHOLD = 1e4
+FLOP_THRESHOLD = 5e6
+
+# Interface flags
+PYTBLIS = getattr(PYSCF, 'pytblis', False)
+OPT_EINSUM = getattr(PYSCF, 'opt_einsum', False)
+
+# Detect backends
+def _has_module(name):
+    try:
+        __import__(name)
+        return True
+    except (ImportError, OSError):
+        return False
+
+_HAS_PYTBLIS = _has_module('pytblis')
+_HAS_OPT_EINSUM = _has_module('opt_einsum')
+
+# Backend priority: provided flags > pytblis > opt_einsum > numpy fallback
+if OPT_EINSUM and _HAS_OPT_EINSUM:
+    EINSUM_BACKEND = "opt_einsum"
+elif PYTBLIS and _HAS_PYTBLIS:
+    EINSUM_BACKEND = "pytblis"
+elif  _HAS_PYTBLIS:
+    EINSUM_BACKEND = "pytblis"
+elif _HAS_OPT_EINSUM:
+    EINSUM_BACKEND = "opt_einsum"
+else:
+    EINSUM_BACKEND = "numpy"
+
+# Import backend
+try:
+    if EINSUM_BACKEND == "pytblis":
+        import pytblis
+        ## TODO: fine tune values for thread control
+        pytblis.set_num_threads(8)
+    elif EINSUM_BACKEND == "opt_einsum":
+        import opt_einsum
+except Exception:
+    EINSUM_BACKEND = "numpy"
+
+_numpy_einsum = numpy.einsum
+
+try:
+    import opt_einsum as _opt_einsum
+    _einsum_path = getattr(_opt_einsum, "contract_path", numpy.einsum_path)
+except ImportError:
+    _einsum_path = getattr(numpy, "einsum_path", None)
+
+@lru_cache(maxsize=256)
+def _compiled_opt_expr(subscripts, shapes, optimize):
+    return _opt_einsum.contract_expression(subscripts, *shapes, optimize=optimize)
+
+def contract(subscripts, A, B, **kwargs):
+    '''
+    Perform tensor contraction using einsum notation
+    C = alpha * einsum(subscripts, A, B) + beta * C
+
+    Kwargs:
+        alpha : scalar, optional
+            Default value is 1.
+        beta : scalar, optional
+            Default value is 0.
+        out : ndarray, optional
+            Output tensor to store the result.
+    '''
+    idx_str = subscripts.replace(" ","")
+    # Call numpy.asarray because A or B may be HDF5 Datasets
+    A, B = asarray(A), asarray(B)
+
+    #optimize = kwargs.pop('optimize', True)
+    #if EINSUM_BACKEND == "opt_einsum":
+    #    # compile/reuse cache expression keyed by shapes + optimize
+    #    shapes = (tuple(A.shape), tuple(B.shape))
+    #    expr = _compiled_opt_expr(idx_str, shapes, optimize)
+    #    return expr(A, B, **kwargs)
+
+    if EINSUM_BACKEND == "pytblis":
+       return pytblis.contract(idx_str, A, B, **kwargs)
+
+    # Linear algebra kwargs
+    alpha = kwargs.pop('alpha', 1)
+    beta = kwargs.pop('beta', 0)
+    out = kwargs.pop('out', None)
+
+    # check: binary einsum with an explicit output?
+    if "->" not in idx_str or idx_str.count(",") != 1:
+        return _numpy_einsum(idx_str, A, B, **kwargs)
+
+    # check: valid GEMM contraction?
+    analysis = _analyze_indices(idx_str)
+    if analysis is None:
+        return _numpy_einsum(idx_str, A, B, **kwargs)
+
+    idxA, idxB, idxC, orderA, orderB, permC, shared = analysis
+
+    if A.size == 0 or B.size == 0:
+        shapeA = dict(zip(idxA, A.shape))
+        shapeB = dict(zip(idxB, B.shape))
+        out_shape = (
+            [shapeA[i] for i in idxA if i not in shared] +
+            [shapeB[i] for i in idxB if i not in shared])
+        out_shape = [out_shape[i] for i in permC]
+        return numpy.zeros(out_shape, dtype=numpy.result_type(A, B))
+
+    # check: dimensions valid?
+    if len(idxA) != A.ndim or len(idxB) != B.ndim:
+        return _numpy_einsum(idx_str, A, B, **kwargs)
+
+    shapeA = dict(zip(idxA, A.shape))
+    shapeB = dict(zip(idxB, B.shape))
+
+    inner_dim = 1
+    for s in shared:
+        if shapeA[s] != shapeB[s]:
+            raise ValueError(
+                f"Index '{s}' has incompatible dimensions: "
+                f"{shapeA[s]} vs {shapeB[s]}"
+            )
+        inner_dim *= shapeA[s]
+
+    outer_dim_A = A.size // inner_dim
+    outer_dim_B = B.size // inner_dim
+    flops = outer_dim_A * inner_dim * outer_dim_B
+
+    # check: FLOP threshold met?
+    if flops < FLOP_THRESHOLD:
+        return _numpy_einsum(idx_str, A, B, **kwargs)
+
+    At = A.transpose(orderA).reshape(-1, inner_dim)
+    Bt = B.transpose(orderB).reshape(inner_dim, -1)
+
+    if not At.flags.c_contiguous:
+        At = asarray(At, order="C")
+    if not Bt.flags.c_contiguous:
+        Bt = asarray(Bt, order="C")
+
+    Cmat = dot(At, Bt)
+
+    out_shape = (
+        [shapeA[i] for i in idxA if i not in shared] +
+        [shapeB[i] for i in idxB if i not in shared])
+
+    Cres = Cmat.reshape(out_shape)
+
+    # check if perm is identity
+    if permC != list(range(len(permC))):
+        Cres = Cres.transpose(permC)
+
+    # alpha/beta/out semantics
+    if out is None:
+        return Cres * alpha if alpha != 1 else Cres
+
+    # out provided
+    out_arr = asarray(out)
+    numpy.multiply(Cres, alpha, out=Cres)
+    if beta != 0:
+        numpy.add(Cres, out_arr * beta, out=Cres)
+    # assign to output
+    out_arr[...] = Cres
+    return out
+
+def einsum(scripts, *tensors, **kwargs):
+    '''
+    Perform a more efficient einsum via reshaping to a matrix multiply.
+
+    Current differences compared to numpy.einsum:
+    This assumes that each repeated index is actually summed (i.e. no 'i,i->i')
+    and appears only twice (i.e. no 'ij,ik,il->jkl'). The output indices must
+    be explicitly specified (i.e. 'ij,j->i' and not 'ij,j').
+    '''
+    subscripts = scripts.replace(" ","")
+    tensors = tuple(asarray(t) for t in tensors)
+
+    if len(tensors) <= 1 or '...' in subscripts:
+        return _numpy_einsum(subscripts, *tensors, **kwargs)
+
+    #if EINSUM_BACKEND == "pytblis":
+    if EINSUM_BACKEND == "pytblis" and len(tensors) < 4:
+        if kwargs.get("optimize") is True:
+           kwargs["optimize"] = "optimal"
+        return pytblis.einsum(subscripts, *tensors, **kwargs)
+
+    optimize = kwargs.pop('optimize', True)
+    if EINSUM_BACKEND == "opt_einsum":
+        shapes = tuple(tuple(t.shape) for t in tensors)
+        expr = _compiled_opt_expr(subscripts, shapes, optimize)
+        return expr(*tensors)
+
+    _contract = kwargs.pop('_contract', contract)
+    if len(tensors) <= 2:
+        return _contract(subscripts, *tensors, **kwargs)
+
+    _, contraction_list = _einsum_path(subscripts, *tensors, optimize=optimize, einsum_call=True)
+
+    ##TODO: add in handling of in-place contraction (see numpy/numpy/blob/v2.4.0/numpy/_core/einsumfunc.py)
+    operands = list(tensors)
+    for num, contraction in enumerate(contraction_list):
+        # NumPy 2.4.0 >= returns 3 values instead of 5 for einsum path
+        if len(contraction) == 3:
+            inds, einsum_str, _ = contraction
+        else:
+            inds, _, einsum_str, _, _ = contraction
+        ops = [operands[i] for i in inds]
+        fn = _contract if len(ops) == 2 else _numpy_einsum
+        result = fn(einsum_str, *ops, **kwargs)
+        operands = [op for i, op in enumerate(operands) if i not in inds]
+        operands.append(result)
+        del ops, result
+
+    return operands[0]
+
+@lru_cache(maxsize=256)
+def _analyze_indices(idx_str):
+    '''
+    Analyze an einsum index string of the form 'ab,bc->ac'.
+
+    Returns:
+        idxA, idxB, idxC
+        orderA, orderB
+        permC
+        shared
+    '''
+
+    # Split the strings into a list of idx char's
+    try:
+        idxA, idxBC = idx_str.split(",")
+        idxB, idxC = idxBC.split("->")
+    except ValueError:
+        return None
+
+    uniqA = set(idxA)
+    uniqB = set(idxB)
+
+    # reject when indices repeat
+    if len(idxA) != len(uniqA) or len(idxB) != len(uniqB):
+        return None
+
+    shared = sorted(uniqA & uniqB)
+
+    # reject when no indices overlap
+    if not shared:
+        return None
+
+    internal_ind = [i for i in shared if i not in idxC]
+    external_ind = [i for i in shared if i in idxC]
+
+    # reject when no contraction exists
+    if not internal_ind:
+        return None
+
+    external_A = [i for i in idxA if i not in internal_ind]
+    external_B = [i for i in idxB if i not in internal_ind]
+
+    # reject when external index is in both GEMM axes or 
+    # when multiple external indices cannot be flattened
+    if ((external_ind and external_A and external_B) or
+        ((len(external_ind) > 1) and (external_A or external_B))):
+        return None
+
+    # reorder A: [..., internal]
+    idxA_t = external_ind + external_A + internal_ind
+    orderA = [idxA.index(i) for i in idxA_t]
+
+    # reorder B: [internal, ...]
+    idxB_t = external_ind + internal_ind + external_B
+    orderB = [idxB.index(i) for i in idxB_t]
+
+    # output permutation
+    out_idx = external_ind + external_A + external_B
+    if set(out_idx) != set(idxC):
+        return None
+
+    permC = [out_idx.index(i) for i in idxC]
+
+    return idxA, idxB, idxC, orderA, orderB, permC, shared

--- a/mr_adc/compute.py
+++ b/mr_adc/compute.py
@@ -158,8 +158,6 @@ def print_header(mr_adc):
     if mr_adc.e_cas_ci is not None:
         mr_adc.log.extra("CASCI excitation energies (eV):                    %s" % str(h2ev*(mr_adc.e_cas_ci - mr_adc.e_cas)))
 
-    davidson_verbose = 6 if mr_adc.verbose > 3 else 3
-
 def compute_energy(mr_adc):
 
     # Define function for the matrix-vector product S^(-1/2) M S^(-1/2) vec

--- a/mr_adc/compute.py
+++ b/mr_adc/compute.py
@@ -15,7 +15,7 @@
 #
 # Authors: Carlos E. V. de Moura <carlosevmoura@gmail.com>
 #          Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
-#          Donna Odhiambo <donna.odhiambo@proton.me>
+#          Donna H. Odhiambo <donna.odhiambo@proton.me>
 #
 
 import numpy as np
@@ -145,9 +145,11 @@ def print_header(mr_adc):
     mr_adc.log.info("Temporary directory path:                          %s" % mr_adc.temp_dir)
 
     mr_adc.log.info("\nInternal contraction:                              %s" % "Full")
-    mr_adc.log.info("Overlap truncation parameter (singles):            %e" % mr_adc.s_thresh_singles)
-    mr_adc.log.info("Overlap truncation parameter (doubles):            %e" % mr_adc.s_thresh_doubles)
+    mr_adc.log.info("Overlap truncation parameter (singles):            %.2e" % mr_adc.s_thresh_singles)
+    mr_adc.log.info("Overlap truncation parameter (doubles):            %.2e" % mr_adc.s_thresh_doubles)
     mr_adc.log.info("Projector for the semi-internal amplitudes:        %s" % mr_adc.semi_internal_projector)
+
+    mr_adc.log.info("\nEinsum Backend:                                    %s" % mr_adc.interface.einsum_backend)
 
     # Print info about CASCI states
     if mr_adc.ncasci > 0:
@@ -156,6 +158,7 @@ def print_header(mr_adc):
     if mr_adc.e_cas_ci is not None:
         mr_adc.log.extra("CASCI excitation energies (eV):                    %s" % str(h2ev*(mr_adc.e_cas_ci - mr_adc.e_cas)))
 
+    davidson_verbose = 6 if mr_adc.verbose > 3 else 3
 
 def compute_energy(mr_adc):
 

--- a/mr_adc_compute.py
+++ b/mr_adc_compute.py
@@ -15,6 +15,8 @@
 #
 # Authors: Carlos E. V. de Moura <carlosevmoura@gmail.com>
 #          Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
+#                  Ilia M. Mazin <ilia.mazin@gmail.com>
+#              Donna H. Odhiambo <donna.odhiambo@proton.me>
 #
 
 import sys
@@ -64,9 +66,11 @@ def kernel(mr_adc):
     mr_adc.log.info("Temporary directory path:                          %s" % mr_adc.temp_dir)
 
     mr_adc.log.info("\nInternal contraction:                              %s" % "Full")
-    mr_adc.log.info("Overlap truncation parameter (singles):            %e" % mr_adc.s_thresh_singles)
-    mr_adc.log.info("Overlap truncation parameter (doubles):            %e" % mr_adc.s_thresh_doubles)
+    mr_adc.log.info("Overlap truncation parameter (singles):            %.2e" % mr_adc.s_thresh_singles)
+    mr_adc.log.info("Overlap truncation parameter (doubles):            %.2e" % mr_adc.s_thresh_doubles)
     mr_adc.log.info("Projector for the semi-internal amplitudes:        %s" % mr_adc.semi_internal_projector)
+
+    mr_adc.log.info("\nEinsum Backend:                                    %s" % mr_adc.interface.einsum_backend)
 
     # Print info about CASCI states
     if mr_adc.ncasci > 0:
@@ -75,9 +79,7 @@ def kernel(mr_adc):
     if mr_adc.e_cas_ci is not None:
         mr_adc.log.extra("CASCI excitation energies (eV):                    %s" % str(h2ev*(mr_adc.e_cas_ci - mr_adc.e_cas)))
 
-    davidson_verbose = 3
-    if mr_adc.verbose > 3:
-        davidson_verbose = 6
+    davidson_verbose = 6 if mr_adc.verbose > 3 else 3
 
     # Compute amplitudes
     mr_adc_amplitudes.compute_amplitudes(mr_adc)

--- a/nevpt/compute.py
+++ b/nevpt/compute.py
@@ -148,11 +148,12 @@ def print_header(nevpt):
 
     nevpt.log.info("\nInternal contraction:                              %s" % "Full (= Partial)")
     nevpt.log.info("Compute singles amplitudes?                        %s" % str(nevpt.compute_singles_amplitudes))
-    nevpt.log.info("Overlap truncation parameter (singles):            %e" % nevpt.s_thresh_singles)
-    nevpt.log.info("Overlap truncation parameter (doubles):            %e" % nevpt.s_thresh_doubles)
+    nevpt.log.info("Overlap truncation parameter (singles):            %.2e" % nevpt.s_thresh_singles)
+    nevpt.log.info("Overlap truncation parameter (doubles):            %.2e" % nevpt.s_thresh_doubles)
     if nevpt.compute_singles_amplitudes:
         nevpt.log.info("Projector for the semi-internal amplitudes:        %s" % nevpt.semi_internal_projector)
 
+    nevpt.log.info("\nEinsum Backend:                                    %s" % nevpt.interface.einsum_backend)
 
 def print_results(nevpt):
 

--- a/tests/cvs-ip-mr-adc/01-mradc2-h2o-04.py
+++ b/tests/cvs-ip-mr-adc/01-mradc2-h2o-04.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/02-mradc2-h2o-44.py
+++ b/tests/cvs-ip-mr-adc/02-mradc2-h2o-44.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/03-mradc2-h2o-triplet-44.py
+++ b/tests/cvs-ip-mr-adc/03-mradc2-h2o-triplet-44.py
@@ -59,7 +59,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 12

--- a/tests/cvs-ip-mr-adc/04-mradc2-hf-44.py
+++ b/tests/cvs-ip-mr-adc/04-mradc2-hf-44.py
@@ -54,7 +54,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/05-mradc2-n2-66.py
+++ b/tests/cvs-ip-mr-adc/05-mradc2-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # Run MR-ADC computation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.nroots = 12
 mr_adc.ncvs = 2

--- a/tests/cvs-ip-mr-adc/06-mradc2-no-76.py
+++ b/tests/cvs-ip-mr-adc/06-mradc2-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 12

--- a/tests/cvs-ip-mr-adc/07-dfmradc2-h2o-04.py
+++ b/tests/cvs-ip-mr-adc/07-dfmradc2-h2o-04.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/08-dfmradc2-h2o-44.py
+++ b/tests/cvs-ip-mr-adc/08-dfmradc2-h2o-44.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/09-dfmradc2-h2o-triplet-44.py
+++ b/tests/cvs-ip-mr-adc/09-dfmradc2-h2o-triplet-44.py
@@ -59,7 +59,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 12

--- a/tests/cvs-ip-mr-adc/10-dfmradc2-hf-44.py
+++ b/tests/cvs-ip-mr-adc/10-dfmradc2-hf-44.py
@@ -54,7 +54,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/11-dfmradc2-n2-66.py
+++ b/tests/cvs-ip-mr-adc/11-dfmradc2-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # Run MR-ADC computation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.nroots = 12
 mr_adc.ncvs = 2

--- a/tests/cvs-ip-mr-adc/12-dfmradc2-no-76.py
+++ b/tests/cvs-ip-mr-adc/12-dfmradc2-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 12

--- a/tests/cvs-ip-mr-adc/13-mradc2x-h2o-04.py
+++ b/tests/cvs-ip-mr-adc/13-mradc2x-h2o-04.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/14-mradc2x-h2o-44.py
+++ b/tests/cvs-ip-mr-adc/14-mradc2x-h2o-44.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 1

--- a/tests/cvs-ip-mr-adc/15-mradc2x-h2o-triplet-44.py
+++ b/tests/cvs-ip-mr-adc/15-mradc2x-h2o-triplet-44.py
@@ -59,7 +59,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/16-mradc2x-hf-44.py
+++ b/tests/cvs-ip-mr-adc/16-mradc2x-hf-44.py
@@ -54,7 +54,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/17-mradc2x-n2-66.py
+++ b/tests/cvs-ip-mr-adc/17-mradc2x-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # Run MR-ADC computation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.nroots = 4
 mr_adc.ncvs = 2

--- a/tests/cvs-ip-mr-adc/18-mradc2x-no-76.py
+++ b/tests/cvs-ip-mr-adc/18-mradc2x-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/19-dfmradc2x-h2o-04.py
+++ b/tests/cvs-ip-mr-adc/19-dfmradc2x-h2o-04.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/20-dfmradc2x-h2o-44.py
+++ b/tests/cvs-ip-mr-adc/20-dfmradc2x-h2o-44.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 1

--- a/tests/cvs-ip-mr-adc/21-dfmradc2x-h2o-triplet-44.py
+++ b/tests/cvs-ip-mr-adc/21-dfmradc2x-h2o-triplet-44.py
@@ -59,7 +59,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/22-dfmradc2x-hf-44.py
+++ b/tests/cvs-ip-mr-adc/22-dfmradc2x-hf-44.py
@@ -54,7 +54,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 1
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/23-dfmradc2x-n2-66.py
+++ b/tests/cvs-ip-mr-adc/23-dfmradc2x-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # Run MR-ADC computation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.nroots = 4
 mr_adc.ncvs = 2

--- a/tests/cvs-ip-mr-adc/24-dfmradc2x-no-76.py
+++ b/tests/cvs-ip-mr-adc/24-dfmradc2x-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/25-dfmradc2x-disk-n2-66.py
+++ b/tests/cvs-ip-mr-adc/25-dfmradc2x-disk-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # Run MR-ADC computation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.nroots = 4
 mr_adc.ncvs = 2

--- a/tests/cvs-ip-mr-adc/26-dfmradc2x-disk-no-76.py
+++ b/tests/cvs-ip-mr-adc/26-dfmradc2x-disk-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # MR-ADC calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 mr_adc = prism.mr_adc.MRADC(interface)
 mr_adc.ncvs = 2
 mr_adc.nroots = 4

--- a/tests/cvs-ip-mr-adc/27-dfmradc2-ch4-einsum.py
+++ b/tests/cvs-ip-mr-adc/27-dfmradc2-ch4-einsum.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Prism Developers. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v3.0;
+# you may not use this file except in compliance with the License.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License file for the specific language governing
+# permissions and limitations.
+#
+# Available at https://github.com/sokolov-group/prism
+#
+# Authors: Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
+#          Carlos E. V. de Moura <carlosevmoura@gmail.com>
+
+import unittest
+import importlib
+import numpy as np
+import pyscf.gto
+import pyscf.dft
+import pyscf.mcscf
+import prism.interface
+import prism.mr_adc
+
+np.set_printoptions(linewidth=150, edgeitems=10, suppress=True)
+
+mol = pyscf.gto.Mole()
+mol.atom = '''
+C    0.0000   0.0000   0.0000
+H    0.6276   0.6276   0.6276
+H    0.6276  -0.6276  -0.6276
+H   -0.6276   0.6276  -0.6276
+H   -0.6276  -0.6276   0.6276 
+'''
+mol.basis = 'cc-pvdz'
+mol.symmetry = True
+mol.build()
+
+# RKS calculation
+mf = pyscf.dft.RKS(mol)
+mf.xc = 'B3LYP'
+mf.conv_tol = 1e-12
+ehf = mf.scf()
+print("SCF energy: %f\n" % ehf)
+
+# CASSCF calculation
+mc = pyscf.mcscf.CASSCF(mf, 7, 6)
+mc.max_cycle = 100
+mc.conv_tol = 1e-10
+mc.conv_tol_grad = 1e-6
+emc = mc.mc1step()[0]
+print("CASSCF energy: %f\n" % emc)
+
+# MR-ADC calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
+mr_adc_1 = prism.mr_adc.CVSIPMRADC(interface)
+mr_adc_1.ncvs = 1
+mr_adc_1.nroots = 9
+mr_adc_1.s_thresh_singles = 1e-5
+mr_adc_1.s_thresh_doubles = 1e-10
+
+# MR-ADC calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'pytblis').density_fit('cc-pvdz-ri')
+mr_adc_2 = prism.mr_adc.CVSIPMRADC(interface)
+mr_adc_2.ncvs = 1
+mr_adc_2.nroots = 9
+mr_adc_2.s_thresh_singles = 1e-5
+mr_adc_2.s_thresh_doubles = 1e-10
+
+# MR-ADC calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'numpy').density_fit('cc-pvdz-ri')
+mr_adc_3 = prism.mr_adc.CVSIPMRADC(interface)
+mr_adc_3.ncvs = 1
+mr_adc_3.nroots = 9
+mr_adc_3.s_thresh_singles = 1e-5
+mr_adc_3.s_thresh_doubles = 1e-10
+
+class KnownValues(unittest.TestCase):
+
+    def test_pyscf(self):
+       self.assertAlmostEqual(mc.e_tot, -40.2495982004973, 5)
+       self.assertAlmostEqual(mc.e_cas, -9.85045629332514, 4)
+
+    def _check_values(self, e, p):
+        self.assertAlmostEqual(e[0], 293.9668, 3)
+        self.assertAlmostEqual(e[1], 323.0314, 3)
+        self.assertAlmostEqual(e[2], 323.0619, 3)
+        self.assertAlmostEqual(e[3], 324.0186, 3)
+        self.assertAlmostEqual(e[4], 324.0186, 3)
+        self.assertAlmostEqual(e[5], 324.0186, 3)
+        self.assertAlmostEqual(e[6], 324.0186, 3)
+        self.assertAlmostEqual(e[7], 324.0186, 3)
+        self.assertAlmostEqual(e[8], 324.0186, 3)
+
+        self.assertAlmostEqual(p[0], 1.625587, 2)
+        self.assertAlmostEqual(p[1], 0.      , 4)
+        self.assertAlmostEqual(p[2], 0.001240, 4)
+        self.assertAlmostEqual(p[3], 0.000002, 4)
+        self.assertAlmostEqual(p[4], 0.000006, 4)
+        self.assertAlmostEqual(p[5], 0.000006, 4)
+        self.assertAlmostEqual(p[6], 0.000004, 4)
+        self.assertAlmostEqual(p[7], 0.000002, 4)
+        self.assertAlmostEqual(p[8], 0.000004, 4)
+
+    def test_prism_opt_einsum(self):
+        if importlib.util.find_spec('opt_einsum') is None:
+            self.skipTest('opt_einsum is not available')
+        e, p, x = mr_adc_1.kernel()
+        self._check_values(e, p)
+
+    def test_prism_pytblis(self):
+        if importlib.util.find_spec('pytblis') is None:
+            self.skipTest('pytblis is not available')
+        e, p, x = mr_adc_2.kernel()
+        self._check_values(e, p)
+
+    def test_prism_numpy(self):
+        e, p, x = mr_adc_3.kernel()
+        self._check_values(e, p)
+
+if __name__ == "__main__":
+   print("CVS-IP calculations for different CVS-IP-MR-ADC methods")
+   unittest.main()

--- a/tests/cvs-ip-mr-adc/27-dfmradc2-ch4-einsum.ref
+++ b/tests/cvs-ip-mr-adc/27-dfmradc2-ch4-einsum.ref
@@ -1,0 +1,381 @@
+converged SCF energy = -40.515926894204
+SCF energy: -40.515927
+
+CASSCF energy = -40.2495982004973
+CASCI E = -40.2495982004973  E(CI) = -9.85045629332514  S^2 = 0.0000000
+CASSCF energy: -40.249598
+
+
+Computing MR-ADC excitation energies...
+
+Method:                                            cvs-ip-mr-adc(2)
+Nuclear repulsion energy:                         13.472034587382
+Number of electrons:                               10
+Number of basis functions:                         34
+Reference wavefunction type:                       casscf
+Number of core orbitals:                           2
+Number of active orbitals:                         7
+Number of external orbitals:                       25
+Number of active electrons:                        [(3, 3)]
+Reference state active-space energy:              -9.850456293325
+Reference state spin multiplicity:                 [1]
+Number of MR-ADC roots requested:                  9
+Number of CVS orbitals:                            1
+Number of valence (non-CVS) orbitals:              1
+Reference density fitting?                         False
+Correlation density fitting?                       True
+Temporary directory path:                          /scratch/local/odhiambo.5
+
+Internal contraction:                              Full
+Overlap truncation parameter (singles):            1.00e-05
+Overlap truncation parameter (doubles):            1.00e-10
+Projector for the semi-internal amplitudes:        gno
+
+Einsum Backend:                                    opt_einsum
+
+Transforming integrals to MO basis...
+
+Computing reference wavefunction RDMs...
+
+Computing NEVPT2 amplitudes...
+Correlation energy [0']:                          -0.017136423683
+Correlation energy [+1']:                         -0.019120232951
+Correlation energy [-1']:                         -0.015685961556
+Correlation energy [0]:                           -0.004079168342
+Correlation energy [+1]:                          -0.001344812515
+Correlation energy [-1]:                          -0.014248553599
+Correlation energy [+2]:                          -0.002117451757
+Correlation energy [-2]:                          -0.041556975025
+
+Reference energy:                                -40.249598200497
+NEVPT2 correlation energy:                        -0.115289579429
+Total NEVPT2 energy:                             -40.364887779926
+
+Transforming integrals for the CVS calculation...
+
+Dimension of h0 excitation manifold:                       1
+Dimension of h1 excitation manifold:                       800
+Total dimension of the excitation manifold:                801
+Dimension of the orthogonalized excitation manifold:       796
+
+tol 1e-08  toloose 1e-05
+max_cycle 50  max_space 132  max_memory 4000  incore True
+davidson 0 9  |r|= 0.914  e= [11.19655272 11.87591854 11.87893037 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116]  max|de|= 11.9  lindep=    1
+Old state -> New state
+    5     ->     3 
+    3     ->     4 
+    4     ->     5 
+davidson 1 18  |r|= 0.0959  e= [10.80499949 11.87119572 11.87236684 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567]  max|de|= -0.392  lindep= 0.972
+Old state -> New state
+    6     ->     3 
+    8     ->     5 
+    5     ->     6 
+    5     ->     7 
+    7     ->     8 
+Drop eigenvector 1, norm=7.03e-09
+davidson 2 27  |r|= 0.0207  e= [10.80308239 11.87118631 11.87231079 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095]  max|de|= -0.00662  lindep= 0.83
+Old state -> New state
+    4     ->     3 
+    3     ->     5 
+    7     ->     6 
+    8     ->     7 
+    6     ->     8 
+root 1 converged  |r|= 7.03e-09  e= 11.871186313003104  max|de|= -7.11e-15
+davidson 3 35  |r|= 0.00206  e= [10.80308142 11.87118631 11.87230732 11.9074688  11.9074688  11.9074688  11.9074688  11.9074688  11.9074688 ]  max|de|= -0.000252  lindep= 0.865
+Old state -> New state
+    6     ->     4 
+    4     ->     5 
+    8     ->     6 
+    5     ->     8 
+root 0 converged  |r|= 8.32e-07  e= 10.803081422948996  max|de|= -4.84e-10
+davidson 4 43  |r|= 0.000219  e= [10.80308142 11.87118631 11.87230719 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532]  max|de|= -3.48e-06  lindep= 0.921
+Old state -> New state
+    5     ->     4 
+    4     ->     5 
+    8     ->     7 
+    7     ->     8 
+davidson 5 50  |r|= 2.67e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.98e-08  lindep= 0.958
+Old state -> New state
+    7     ->     4 
+    4     ->     5 
+    5     ->     6 
+    6     ->     7 
+root 3 converged  |r|= 1.13e-06  e= 11.907465294470727  max|de|= -3.01e-10
+root 4 converged  |r|= 1.13e-06  e= 11.907465294470738  max|de|= -3.01e-10
+root 5 converged  |r|= 1.13e-06  e= 11.907465294470738  max|de|= -3.01e-10
+root 6 converged  |r|= 1.13e-06  e= 11.907465294470752  max|de|= -3.01e-10
+root 7 converged  |r|= 1.13e-06  e= 11.907465294470759  max|de|= -3.01e-10
+root 8 converged  |r|= 1.13e-06  e= 11.907465294470763  max|de|= -3.01e-10
+davidson 6 57  |r|= 1.22e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -4.15e-10  lindep= 0.884
+Old state -> New state
+    5     ->     4 
+    4     ->     5 
+    7     ->     6 
+    6     ->     7 
+root 2 converged  |r|= 2.09e-06  e= 11.872307178532019  max|de|= -2.17e-11
+converged 7 58  |r|= 2.09e-06  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.17e-11
+
+Summary of results for the CVS-IP-MR-ADC(2) calculation with the CASSCF reference:
+------------------------------------------------------------------------------------------------
+  State        dE(a.u.)        dE(eV)      dE(nm)       dE(cm-1)       Intensity
+------------------------------------------------------------------------------------------------
+    1        10.80308142      293.9668     4.2176    2371002.3129      1.625587
+    2        11.87118631      323.0314     3.8381    2605424.2399      0.000000
+    3        11.87230718      323.0619     3.8378    2605670.2414      0.001240
+    4        11.90746529      324.0186     3.8265    2613386.5560      0.000002
+    5        11.90746529      324.0186     3.8265    2613386.5560      0.000006
+    6        11.90746529      324.0186     3.8265    2613386.5560      0.000006
+    7        11.90746529      324.0186     3.8265    2613386.5560      0.000004
+    8        11.90746529      324.0186     3.8265    2613386.5560      0.000002
+    9        11.90746529      324.0186     3.8265    2613386.5560      0.000004
+------------------------------------------------------------------------------------------------
+> CPU time for total CVS-IP-MR-ADC(2) calculation     42.20 sec, wall time      3.52 sec
+
+Computing MR-ADC excitation energies...
+
+Method:                                            cvs-ip-mr-adc(2)
+Nuclear repulsion energy:                         13.472034587382
+Number of electrons:                               10
+Number of basis functions:                         34
+Reference wavefunction type:                       casscf
+Number of core orbitals:                           2
+Number of active orbitals:                         7
+Number of external orbitals:                       25
+Number of active electrons:                        [(3, 3)]
+Reference state active-space energy:              -9.850456293325
+Reference state spin multiplicity:                 [1]
+Number of MR-ADC roots requested:                  9
+Number of CVS orbitals:                            1
+Number of valence (non-CVS) orbitals:              1
+Reference density fitting?                         False
+Correlation density fitting?                       True
+Temporary directory path:                          /scratch/local/odhiambo.5
+
+Internal contraction:                              Full
+Overlap truncation parameter (singles):            1.00e-05
+Overlap truncation parameter (doubles):            1.00e-10
+Projector for the semi-internal amplitudes:        gno
+
+Einsum Backend:                                    pytblis
+
+Transforming integrals to MO basis...
+
+Computing reference wavefunction RDMs...
+
+Computing NEVPT2 amplitudes...
+Correlation energy [0']:                          -0.017136423683
+Correlation energy [+1']:                         -0.019120232951
+Correlation energy [-1']:                         -0.015685961556
+Correlation energy [0]:                           -0.004079168342
+Correlation energy [+1]:                          -0.001344812515
+Correlation energy [-1]:                          -0.014248553599
+Correlation energy [+2]:                          -0.002117451757
+Correlation energy [-2]:                          -0.041556975025
+
+Reference energy:                                -40.249598200497
+NEVPT2 correlation energy:                        -0.115289579429
+Total NEVPT2 energy:                             -40.364887779926
+
+Transforming integrals for the CVS calculation...
+
+Dimension of h0 excitation manifold:                       1
+Dimension of h1 excitation manifold:                       800
+Total dimension of the excitation manifold:                801
+Dimension of the orthogonalized excitation manifold:       796
+
+tol 1e-08  toloose 1e-05
+max_cycle 50  max_space 132  max_memory 4000  incore True
+davidson 0 9  |r|= 0.914  e= [11.19655272 11.87591854 11.87893037 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116]  max|de|= 11.9  lindep=    1
+Old state -> New state
+    6     ->     4 
+    4     ->     5 
+    5     ->     6 
+    8     ->     7 
+    7     ->     8 
+davidson 1 18  |r|= 0.0959  e= [10.80499949 11.87119572 11.87236684 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567]  max|de|= -0.392  lindep= 0.972
+Old state -> New state
+    6     ->     5 
+    5     ->     7 
+    7     ->     8 
+Drop eigenvector 1, norm=7.03e-09
+davidson 2 27  |r|= 0.0207  e= [10.80308239 11.87118631 11.87231079 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095]  max|de|= 11.9  lindep= 0.83
+Old state -> New state
+    8     ->     5 
+    7     ->     6 
+    6     ->     7 
+    5     ->     8 
+root 1 converged  |r|= 7.03e-09  e= 11.871186313003097  max|de|= -1.6e-14
+davidson 3 35  |r|= 0.00206  e= [10.80308142 11.87118631 11.87230732 11.9074688  11.9074688  11.9074688  11.9074688  11.9074688  11.9074688 ]  max|de|= -0.000252  lindep= 0.865
+Old state -> New state
+    6     ->     3 
+    3     ->     4 
+    4     ->     5 
+    7     ->     6 
+    8     ->     7 
+    4     ->     8 
+root 0 converged  |r|= 8.32e-07  e= 10.803081422948999  max|de|= -4.84e-10
+davidson 4 43  |r|= 0.000219  e= [10.80308142 11.87118631 11.87230719 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532]  max|de|= -3.48e-06  lindep= 0.921
+Old state -> New state
+    6     ->     3 
+    3     ->     5 
+    5     ->     6 
+davidson 5 50  |r|= 2.67e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.98e-08  lindep= 0.958
+Old state -> New state
+    4     ->     3 
+    5     ->     4 
+    8     ->     5 
+    7     ->     6 
+    3     ->     7 
+    7     ->     8 
+root 3 converged  |r|= 1.13e-06  e= 11.90746529447073  max|de|= -3.01e-10
+root 4 converged  |r|= 1.13e-06  e= 11.907465294470732  max|de|= -3.01e-10
+root 5 converged  |r|= 1.13e-06  e= 11.907465294470743  max|de|= -3.01e-10
+root 6 converged  |r|= 1.13e-06  e= 11.90746529447075  max|de|= -3.01e-10
+root 7 converged  |r|= 1.13e-06  e= 11.907465294470754  max|de|= -3.01e-10
+root 8 converged  |r|= 1.13e-06  e= 11.907465294470764  max|de|= -3.01e-10
+davidson 6 57  |r|= 1.22e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -4.15e-10  lindep= 0.884
+Old state -> New state
+    4     ->     3 
+    3     ->     4 
+    7     ->     6 
+    8     ->     7 
+    6     ->     8 
+root 2 converged  |r|= 2.09e-06  e= 11.872307178532024  max|de|= -2.17e-11
+converged 7 58  |r|= 2.09e-06  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.17e-11
+
+Summary of results for the CVS-IP-MR-ADC(2) calculation with the CASSCF reference:
+------------------------------------------------------------------------------------------------
+  State        dE(a.u.)        dE(eV)      dE(nm)       dE(cm-1)       Intensity
+------------------------------------------------------------------------------------------------
+    1        10.80308142      293.9668     4.2176    2371002.3129      1.625587
+    2        11.87118631      323.0314     3.8381    2605424.2399      0.000000
+    3        11.87230718      323.0619     3.8378    2605670.2414      0.001240
+    4        11.90746529      324.0186     3.8265    2613386.5560      0.000004
+    5        11.90746529      324.0186     3.8265    2613386.5560      0.000004
+    6        11.90746529      324.0186     3.8265    2613386.5560      0.000005
+    7        11.90746529      324.0186     3.8265    2613386.5560      0.000008
+    8        11.90746529      324.0186     3.8265    2613386.5560      0.000002
+    9        11.90746529      324.0186     3.8265    2613386.5560      0.000002
+------------------------------------------------------------------------------------------------
+> CPU time for total CVS-IP-MR-ADC(2) calculation     43.35 sec, wall time      3.62 sec
+
+Computing MR-ADC excitation energies...
+
+Method:                                            cvs-ip-mr-adc(2)
+Nuclear repulsion energy:                         13.472034587382
+Number of electrons:                               10
+Number of basis functions:                         34
+Reference wavefunction type:                       casscf
+Number of core orbitals:                           2
+Number of active orbitals:                         7
+Number of external orbitals:                       25
+Number of active electrons:                        [(3, 3)]
+Reference state active-space energy:              -9.850456293325
+Reference state spin multiplicity:                 [1]
+Number of MR-ADC roots requested:                  9
+Number of CVS orbitals:                            1
+Number of valence (non-CVS) orbitals:              1
+Reference density fitting?                         False
+Correlation density fitting?                       True
+Temporary directory path:                          /scratch/local/odhiambo.5
+
+Internal contraction:                              Full
+Overlap truncation parameter (singles):            1.00e-05
+Overlap truncation parameter (doubles):            1.00e-10
+Projector for the semi-internal amplitudes:        gno
+
+Einsum Backend:                                    numpy
+
+Transforming integrals to MO basis...
+
+Computing reference wavefunction RDMs...
+
+Computing NEVPT2 amplitudes...
+Correlation energy [0']:                          -0.017136423683
+Correlation energy [+1']:                         -0.019120232951
+Correlation energy [-1']:                         -0.015685961556
+Correlation energy [0]:                           -0.004079168342
+Correlation energy [+1]:                          -0.001344812515
+Correlation energy [-1]:                          -0.014248553599
+Correlation energy [+2]:                          -0.002117451757
+Correlation energy [-2]:                          -0.041556975025
+
+Reference energy:                                -40.249598200497
+NEVPT2 correlation energy:                        -0.115289579429
+Total NEVPT2 energy:                             -40.364887779926
+
+Transforming integrals for the CVS calculation...
+
+Dimension of h0 excitation manifold:                       1
+Dimension of h1 excitation manifold:                       800
+Total dimension of the excitation manifold:                801
+Dimension of the orthogonalized excitation manifold:       796
+
+tol 1e-08  toloose 1e-05
+max_cycle 50  max_space 132  max_memory 4000  incore True
+davidson 0 9  |r|= 0.914  e= [11.19655272 11.87591854 11.87893037 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116 11.93311116]  max|de|= 11.9  lindep=    1
+Old state -> New state
+    5     ->     4 
+    4     ->     5 
+davidson 1 18  |r|= 0.0959  e= [10.80499949 11.87119572 11.87236684 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567 11.91434567]  max|de|= -0.392  lindep= 0.972
+Old state -> New state
+    6     ->     3 
+    3     ->     4 
+    8     ->     6 
+    4     ->     7 
+    7     ->     8 
+Drop eigenvector 1, norm=7.03e-09
+davidson 2 27  |r|= 0.0207  e= [10.80308239 11.87118631 11.87231079 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095 11.90772095]  max|de|= -0.00662  lindep= 0.83
+Old state -> New state
+    3     ->     4 
+    7     ->     6 
+    6     ->     7 
+root 1 converged  |r|= 7.03e-09  e= 11.871186313003104  max|de|= 1.78e-15
+davidson 3 35  |r|= 0.00206  e= [10.80308142 11.87118631 11.87230732 11.9074688  11.9074688  11.9074688  11.9074688  11.9074688  11.9074688 ]  max|de|= -0.000252  lindep= 0.865
+Old state -> New state
+    4     ->     3 
+    3     ->     4 
+    7     ->     5 
+root 0 converged  |r|= 8.32e-07  e= 10.803081422948988  max|de|= -4.84e-10
+davidson 4 43  |r|= 0.000219  e= [10.80308142 11.87118631 11.87230719 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532 11.90746532]  max|de|= -3.48e-06  lindep= 0.921
+Old state -> New state
+    4     ->     3 
+    3     ->     4 
+    6     ->     5 
+    5     ->     7 
+davidson 5 50  |r|= 2.67e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.98e-08  lindep= 0.958
+Old state -> New state
+    4     ->     3 
+    3     ->     4 
+    7     ->     5 
+    5     ->     7 
+root 3 converged  |r|= 1.13e-06  e= 11.907465294470722  max|de|= -3.01e-10
+root 4 converged  |r|= 1.13e-06  e= 11.907465294470725  max|de|= -3.01e-10
+root 5 converged  |r|= 1.13e-06  e= 11.907465294470734  max|de|= -3.01e-10
+root 6 converged  |r|= 1.13e-06  e= 11.907465294470736  max|de|= -3.01e-10
+root 7 converged  |r|= 1.13e-06  e= 11.907465294470738  max|de|= -3.01e-10
+root 8 converged  |r|= 1.13e-06  e= 11.907465294470752  max|de|= -3.01e-10
+davidson 6 57  |r|= 1.22e-05  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -4.15e-10  lindep= 0.884
+Old state -> New state
+    4     ->     3 
+    3     ->     4 
+    7     ->     6 
+    6     ->     7 
+root 2 converged  |r|= 2.09e-06  e= 11.872307178532019  max|de|= -2.17e-11
+converged 7 58  |r|= 2.09e-06  e= [10.80308142 11.87118631 11.87230718 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529 11.90746529]  max|de|= -2.17e-11
+
+Summary of results for the CVS-IP-MR-ADC(2) calculation with the CASSCF reference:
+------------------------------------------------------------------------------------------------
+  State        dE(a.u.)        dE(eV)      dE(nm)       dE(cm-1)       Intensity
+------------------------------------------------------------------------------------------------
+    1        10.80308142      293.9668     4.2176    2371002.3129      1.625587
+    2        11.87118631      323.0314     3.8381    2605424.2399      0.000000
+    3        11.87230718      323.0619     3.8378    2605670.2414      0.001240
+    4        11.90746529      324.0186     3.8265    2613386.5560      0.000003
+    5        11.90746529      324.0186     3.8265    2613386.5560      0.000007
+    6        11.90746529      324.0186     3.8265    2613386.5560      0.000000
+    7        11.90746529      324.0186     3.8265    2613386.5560      0.000004
+    8        11.90746529      324.0186     3.8265    2613386.5560      0.000005
+    9        11.90746529      324.0186     3.8265    2613386.5560      0.000005
+------------------------------------------------------------------------------------------------
+> CPU time for total CVS-IP-MR-ADC(2) calculation     43.35 sec, wall time      9.07 sec

--- a/tests/nevpt2/01-nevpt2-h2o-04.py
+++ b/tests/nevpt2/01-nevpt2-h2o-04.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/02-nevpt2-h2o-44.py
+++ b/tests/nevpt2/02-nevpt2-h2o-44.py
@@ -56,7 +56,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/03-nevpt2-h2o-triplet-66.py
+++ b/tests/nevpt2/03-nevpt2-h2o-triplet-66.py
@@ -60,7 +60,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/04-dfnevpt2-hf-44.py
+++ b/tests/nevpt2/04-dfnevpt2-hf-44.py
@@ -54,7 +54,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = True
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/05-dfnevpt2-n2-66.py
+++ b/tests/nevpt2/05-dfnevpt2-n2-66.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = True
 nevpt.semi_internal_projector = "gs"

--- a/tests/nevpt2/06-dfnevpt2-no-76.py
+++ b/tests/nevpt2/06-dfnevpt2-no-76.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/07-dfnevpt2-n2-88.py
+++ b/tests/nevpt2/07-dfnevpt2-n2-88.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gs"

--- a/tests/nevpt2/08-dfnevpt2-no-79.py
+++ b/tests/nevpt2/08-dfnevpt2-no-79.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/09-dfnevpt2-fc-n2-88.py
+++ b/tests/nevpt2/09-dfnevpt2-fc-n2-88.py
@@ -52,7 +52,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gs"

--- a/tests/nevpt2/10-dfnevpt2-fc-no-79.py
+++ b/tests/nevpt2/10-dfnevpt2-fc-no-79.py
@@ -62,7 +62,7 @@ emc = mc.mc1step()[0]
 print("CASSCF energy: %f\n" % emc)
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/11-nevpt2-sa-casscf-h2o-66.py
+++ b/tests/nevpt2/11-nevpt2-sa-casscf-h2o-66.py
@@ -57,7 +57,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/12-nevpt2-ms-casci-h2o-66.py
+++ b/tests/nevpt2/12-nevpt2-ms-casci-h2o-66.py
@@ -55,7 +55,7 @@ mc.fcisolver.nroots = n_states
 emc = mc.casci()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/13-dfnevpt2-sa-casscf-n2-88.py
+++ b/tests/nevpt2/13-dfnevpt2-sa-casscf-n2-88.py
@@ -53,7 +53,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/14-dfnevpt2-sa-casscf-no-76.py
+++ b/tests/nevpt2/14-dfnevpt2-sa-casscf-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/15-dfnevpt2-fc-sa-casscf-n2-88.py
+++ b/tests/nevpt2/15-dfnevpt2-fc-sa-casscf-n2-88.py
@@ -53,7 +53,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/16-dfnevpt2-fc-sa-casscf-no-76.py
+++ b/tests/nevpt2/16-dfnevpt2-fc-sa-casscf-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/17-dfnevpt2-fc-sa-casscf-disk-n2-88.py
+++ b/tests/nevpt2/17-dfnevpt2-fc-sa-casscf-disk-n2-88.py
@@ -53,7 +53,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/18-dfnevpt2-fc-sa-casscf-disk-no-76.py
+++ b/tests/nevpt2/18-dfnevpt2-fc-sa-casscf-disk-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/19-nevpt2-sa-casscf-h2o-66-1rdm.py
+++ b/tests/nevpt2/19-nevpt2-sa-casscf-h2o-66-1rdm.py
@@ -57,7 +57,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.NEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/nevpt2/20-dfnevpt2-no-79-einsum.py
+++ b/tests/nevpt2/20-dfnevpt2-no-79-einsum.py
@@ -1,0 +1,117 @@
+# Copyright 2026 Prism Developers. All Rights Reserved.
+#
+# Licensed under the GNU General Public License v3.0;
+# you may not use this file except in compliance with the License.
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+# either express or implied.
+#
+# See the License file for the specific language governing
+# permissions and limitations.
+#
+# Available at https://github.com/sokolov-group/prism
+#
+# Authors: Alexander Yu. Sokolov <alexander.y.sokolov@gmail.com>
+#          Carlos E. V. de Moura <carlosevmoura@gmail.com>
+
+import unittest
+import importlib
+import numpy as np
+import pyscf.gto
+import pyscf.scf
+import pyscf.mcscf
+import prism.interface
+import prism.nevpt
+
+np.set_printoptions(linewidth=150, edgeitems=10, suppress=True)
+
+r = 1.1508
+
+mol = pyscf.gto.Mole()
+mol.atom = [
+            ['N', (0.0, 0.0, 0.0)],
+            ['O', (0.0, 0.0,   r)]]
+mol.basis = 'cc-pcvdz'
+mol.symmetry = True
+mol.spin = 0
+mol.charge = +1
+mol.build()
+
+# RHF calculation
+mf = pyscf.scf.RHF(mol)
+mf.max_cycle = 250
+mf.conv_tol = 1e-12
+
+ehf = mf.scf()
+print("SCF energy: %f\n" % ehf)
+
+mol.spin = 1
+mol.charge = 0
+mol.build()
+
+# CASSCF calculation
+mc = pyscf.mcscf.CASSCF(mf, 9, 7)
+mc.max_cycle = 150
+mc.conv_tol = 1e-8
+mc.conv_tol_grad = 1e-5
+mc.fcisolver.wfnsym = 'E1x'
+
+emc = mc.mc1step()[0]
+print("CASSCF energy: %f\n" % emc)
+
+# NEVPT2 calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
+nevpt_1 = prism.nevpt.NEVPT(interface)
+nevpt_1.compute_singles_amplitudes = False
+nevpt_1.semi_internal_projector = "gno"
+nevpt_1.s_thresh_singles = 1e-6
+nevpt_1.s_thresh_doubles = 1e-10
+
+# NEVPT2 calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'pytblis').density_fit('cc-pvdz-ri')
+nevpt_2 = prism.nevpt.NEVPT(interface)
+nevpt_2.compute_singles_amplitudes = False
+nevpt_2.semi_internal_projector = "gno"
+nevpt_2.s_thresh_singles = 1e-6
+nevpt_2.s_thresh_doubles = 1e-10
+
+# NEVPT2 calculation
+interface = prism.interface.PYSCF(mf, mc, backend = 'numpy').density_fit('cc-pvdz-ri')
+nevpt_3 = prism.nevpt.NEVPT(interface)
+nevpt_3.compute_singles_amplitudes = False
+nevpt_3.semi_internal_projector = "gno"
+nevpt_3.s_thresh_singles = 1e-6
+nevpt_3.s_thresh_doubles = 1e-10
+
+class KnownValues(unittest.TestCase):
+
+    def test_pyscf(self):
+        self.assertAlmostEqual(mc.e_tot, -129.402145048918, 6)
+        self.assertAlmostEqual(mc.e_cas,  -17.587633940679, 6)
+
+    def _check_values(self, e_tot, e_corr):
+
+        self.assertAlmostEqual(e_tot[0], -129.649975169028, 6)
+        self.assertAlmostEqual(e_corr[0],  -0.247830120110, 6)
+
+    def test_prism_opt_einsum(self):
+        if importlib.util.find_spec('opt_einsum') is None:
+            self.skipTest('opt_einsum is not available')
+        e_tot, e_corr, osc = nevpt_1.kernel()
+        self._check_values(e_tot, e_corr)
+
+    def test_prism_pytblis(self):
+        if importlib.util.find_spec('pytblis') is None:
+            self.skipTest('pytblis is not available')
+        e_tot, e_corr, osc = nevpt_2.kernel()
+        self._check_values(e_tot, e_corr)
+
+    def test_prism_numpy(self):
+        e_tot, e_corr, osc = nevpt_3.kernel()
+        self._check_values(e_tot, e_corr)
+
+if __name__ == "__main__":
+    print("NEVPT2 test")
+    unittest.main()

--- a/tests/nevpt2/20-dfnevpt2-no-79-einsum.ref
+++ b/tests/nevpt2/20-dfnevpt2-no-79-einsum.ref
@@ -1,0 +1,49 @@
+converged SCF energy = -128.887431608627
+SCF energy: -128.887432
+
+CASSCF energy = -129.402145048918
+CASCI E = -129.402145048918  E(CI) = -17.5876339406787  S^2 = 0.7500000
+CASSCF energy: -129.402145
+
+NEVPT2 test
+
+Transforming integrals to MO basis...
+
+Computing NEVPT energies...
+
+Method:                                            nevpt2
+Nuclear repulsion energy:                         25.750715859854
+Number of electrons:                               15
+Number of basis functions:                         36
+Reference wavefunction type:                       casscf
+Number of reference states:                        1
+Number of reference microstates:                   2
+Number of frozen orbitals:                         0
+Number of core orbitals:                           4
+Number of active orbitals:                         9
+Number of external orbitals:                       23
+Reference density fitting?                         False
+Correlation density fitting?                       True
+Temporary directory path:                          /scratch/local
+
+Internal contraction:                              Full (= Partial)
+Compute singles amplitudes?                        False
+Overlap truncation parameter (singles):            1.000000e-06
+Overlap truncation parameter (doubles):            1.000000e-10
+
+Computing energy of state #1...
+Reference state active-space energy:             -17.587633940679
+Reference state spin multiplicity:                 2
+Number of active electrons:                        [(4, 3), (3, 4)]
+Correlation energy [0']:                          -0.069485098219
+Correlation energy [+1']:                         -0.006917122921
+Correlation energy [-1']:                         -0.027517363970
+Correlation energy [0]:                           -0.072342695713
+Correlation energy [+1]:                          -0.010573870605
+Correlation energy [-1]:                          -0.021880349096
+Correlation energy [+2]:                          -0.004652463161
+Correlation energy [-2]:                          -0.034461156424
+CASSCF reference state total energy:            -129.402145048918
+NEVPT2 correlation energy:                        -0.247830120110
+Total NEVPT2 energy:                            -129.649975169028
+> CPU time for total NEVPT2 calculation    178.09 sec, wall time     13.25 sec

--- a/tests/qdnevpt2/01-qdnevpt2-h2o-66.py
+++ b/tests/qdnevpt2/01-qdnevpt2-h2o-66.py
@@ -65,7 +65,7 @@ class KnownValues(unittest.TestCase):
     def test_prism(self):
 
         # QD-NEVPT2 calculation
-        interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+        interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
         nevpt = prism.nevpt.NEVPT(interface)
         nevpt.compute_singles_amplitudes = False
         nevpt.semi_internal_projector = "gno"
@@ -98,7 +98,7 @@ class KnownValues(unittest.TestCase):
     def test_prism2(self):
 
         # QD-NEVPT2 calculation
-        interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+        interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
         nevpt = prism.nevpt.QDNEVPT(interface)
         nevpt.compute_singles_amplitudes = False
         nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/02-df-qdnevpt2-n2-88.py
+++ b/tests/qdnevpt2/02-df-qdnevpt2-n2-88.py
@@ -53,7 +53,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/03-df-qdnevpt2-no-76.py
+++ b/tests/qdnevpt2/03-df-qdnevpt2-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/04-df-fc-qdnevpt2-n2-88.py
+++ b/tests/qdnevpt2/04-df-fc-qdnevpt2-n2-88.py
@@ -53,7 +53,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('aug-cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('aug-cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/05-df-fc-qdnevpt2-no-76.py
+++ b/tests/qdnevpt2/05-df-fc-qdnevpt2-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/06-qdnevpt2-disk-h2o-66.py
+++ b/tests/qdnevpt2/06-qdnevpt2-disk-h2o-66.py
@@ -57,7 +57,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # QD-NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/07-df-fc-qdnevpt2-disk-no-76.py
+++ b/tests/qdnevpt2/07-df-fc-qdnevpt2-disk-no-76.py
@@ -61,7 +61,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True).density_fit('cc-pvdz-ri')
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum').density_fit('cc-pvdz-ri')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"

--- a/tests/qdnevpt2/08-qdnevpt2-h2o-66-1rdm.py
+++ b/tests/qdnevpt2/08-qdnevpt2-h2o-66-1rdm.py
@@ -57,7 +57,7 @@ mc.conv_tol_grad = 1e-6
 emc = mc.mc1step()[0]
 
 # NEVPT2 calculation
-interface = prism.interface.PYSCF(mf, mc, opt_einsum = True)
+interface = prism.interface.PYSCF(mf, mc, backend = 'opt_einsum')
 nevpt = prism.nevpt.QDNEVPT(interface)
 nevpt.compute_singles_amplitudes = False
 nevpt.semi_internal_projector = "gno"


### PR DESCRIPTION
This PR adds the pytblis package (https://github.com/chillenb/pytblis) as a backend option for einsum contractions.
When no user-provided flags are specified, the code automatically checks for available packages and uses the following fallback priority: pytblis > opt_einsum > numpy.